### PR TITLE
Feat/Add interactive DSA drills and expand pandas practice prompts

### DIFF
--- a/data_science_prep/docs/computer-science-data-scructures-and-algorithms.html
+++ b/data_science_prep/docs/computer-science-data-scructures-and-algorithms.html
@@ -204,10 +204,27 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <ul>
 <li class="chapter" data-level="6.1" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#sample-questions-4"><i class="fa fa-check"></i><b>6.1</b> Sample Questions</a>
 <ul>
-<li class="chapter" data-level="6.1.1" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#calulate-moving-average-using-python"><i class="fa fa-check"></i><b>6.1.1</b> Calulate moving average using Python</a></li>
-<li class="chapter" data-level="6.1.2" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#python-function-to-express-power-sets"><i class="fa fa-check"></i><b>6.1.2</b> Python function to express power sets</a></li>
-<li class="chapter" data-level="6.1.3" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#if-you-were-given-a-m-by-n-matrix-how-would-you-find-the-minimum-element-using-brute-force-algorithm"><i class="fa fa-check"></i><b>6.1.3</b> If you were given a m by n matrix how would you find the minimum element using brute force algorithm</a></li>
-<li class="chapter" data-level="6.1.4" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#finding-the-value-closest-to-0"><i class="fa fa-check"></i><b>6.1.4</b> Finding the value closest to 0</a></li>
+<li class="chapter" data-level="6.1.1" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#popular-questions"><i class="fa fa-check"></i><b>6.1.1</b> Popular Questions</a>
+<ul>
+<li class="chapter" data-level="6.1.1.1" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#two-sum"><i class="fa fa-check"></i>Two Sum</a></li>
+<li class="chapter" data-level="6.1.1.2" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#merge-sorted-array"><i class="fa fa-check"></i>Merge Sorted Array</a></li>
+<li class="chapter" data-level="6.1.1.3" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#hello-world-function"><i class="fa fa-check"></i>Create Hello World Function</a></li>
+<li class="chapter" data-level="6.1.1.4" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#basic-calculator-ii"><i class="fa fa-check"></i>Basic Calculator II</a></li>
+<li class="chapter" data-level="6.1.1.5" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#find-peak-element"><i class="fa fa-check"></i>Find Peak Element</a></li>
+<li class="chapter" data-level="6.1.1.6" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#subarray-sum-equals-k"><i class="fa fa-check"></i>Subarray Sum Equals K</a></li>
+<li class="chapter" data-level="6.1.1.7" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#merge-intervals"><i class="fa fa-check"></i>Merge Intervals</a></li>
+<li class="chapter" data-level="6.1.1.8" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#merge-strings-alternately"><i class="fa fa-check"></i>Merge Strings Alternately</a></li>
+<li class="chapter" data-level="6.1.1.9" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#add-two-numbers"><i class="fa fa-check"></i>Add Two Numbers</a></li>
+<li class="chapter" data-level="6.1.1.10" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#lowest-common-ancestor"><i class="fa fa-check"></i>Lowest Common Ancestor of a Binary Tree</a></li>
+</ul></li>
+<li class="chapter" data-level="6.1.2" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#dsa-other-questions"><i class="fa fa-check"></i><b>6.1.2</b> Other Questions</a>
+<ul>
+<li class="chapter" data-level="6.1.2.1" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#moving-average"><i class="fa fa-check"></i>Calculate Moving Average Using Python</a></li>
+<li class="chapter" data-level="6.1.2.2" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#power-set"><i class="fa fa-check"></i>Python Function to Express Power Sets</a></li>
+<li class="chapter" data-level="6.1.2.3" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#find-min-in-matrix"><i class="fa fa-check"></i>Find the Minimum Element in a Matrix</a></li>
+<li class="chapter" data-level="6.1.2.4" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#closest-value"><i class="fa fa-check"></i>Finding the Value Closest to 0</a></li>
+<li class="chapter" data-level="6.1.2.5" data-path="computer-science-data-scructures-and-algorithms.html"><a href="computer-science-data-scructures-and-algorithms.html#points-within-interval"><i class="fa fa-check"></i>Points Within an Interval</a></li>
+</ul></li>
 </ul></li>
 </ul></li>
 <li class="chapter" data-level="7" data-path="pandas-practice.html"><a href="pandas-practice.html"><i class="fa fa-check"></i><b>7</b> Pandas Practice</a>
@@ -247,182 +264,22 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
             <section class="normal" id="section-">
 <div id="computer-science-data-scructures-and-algorithms" class="section level1 hasAnchor" number="6">
 <h1><span class="header-section-number">Chapter 6</span> Computer Science / Data Scructures and Algorithms<a href="computer-science-data-scructures-and-algorithms.html#computer-science-data-scructures-and-algorithms" class="anchor-section" aria-label="Anchor link to header"></a></h1>
+<p>For many data science interviews, the DSA bar is lower than it is for dedicated software engineering roles, but it is not safe to assume it will always be light. Expectations vary a lot by company, team, and title: analytics-focused roles may only test basic problem solving, while product, ML, or platform-oriented data science roles can still include meaningful coding rounds. In practice, being comfortable with common Easy and Medium LeetCode-style questions is a strong baseline, especially for larger or more competitive companies that want to see solid programming fundamentals in addition to statistics, experimentation, and business sense.</p>
 <div id="sample-questions-4" class="section level2 hasAnchor" number="6.1">
 <h2><span class="header-section-number">6.1</span> Sample Questions<a href="computer-science-data-scructures-and-algorithms.html#sample-questions-4" class="anchor-section" aria-label="Anchor link to header"></a></h2>
-<div id="calulate-moving-average-using-python" class="section level3 hasAnchor" number="6.1.1">
-<h3><span class="header-section-number">6.1.1</span> Calulate moving average using Python<a href="computer-science-data-scructures-and-algorithms.html#calulate-moving-average-using-python" class="anchor-section" aria-label="Anchor link to header"></a></h3>
-<ul>
-<li>Python</li>
-<li>Moving Average</li>
-<li>Data Structures</li>
-<li>Array</li>
-</ul>
-<p>You are given a list of numbers J and a single number p. Write a function to return the minimum and maximum averages of the sequences of p numbers in the list J.</p>
-<p>For example:</p>
-<pre><code># Array of numbers
-J = [4, 4, 4, 9, 10, 11, 12]
-# Length of sequences, p
-p = 3</code></pre>
-<p>Here, the sequences will be:</p>
-<p>(4,4,4)
-(4,4,9)
-(4,9,10)
-(9,10,11)
-(10,11,12)
-From the above we can see that the minimum average will be 4 and the maximum average will be 11, which corresponds to the first and last sequences.</p>
-<div class="sourceCode" id="cb87"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb87-1"><a href="computer-science-data-scructures-and-algorithms.html#cb87-1" aria-hidden="true" tabindex="-1"></a><span class="co"># if always sorted can just do the first 3 and last 3</span></span>
-<span id="cb87-2"><a href="computer-science-data-scructures-and-algorithms.html#cb87-2" aria-hidden="true" tabindex="-1"></a>J <span class="op">=</span> [<span class="dv">4</span>, <span class="dv">4</span>, <span class="dv">4</span>, <span class="dv">9</span>, <span class="dv">10</span>, <span class="dv">11</span>, <span class="dv">12</span>]</span>
-<span id="cb87-3"><a href="computer-science-data-scructures-and-algorithms.html#cb87-3" aria-hidden="true" tabindex="-1"></a>p <span class="op">=</span> <span class="dv">3</span></span>
-<span id="cb87-4"><a href="computer-science-data-scructures-and-algorithms.html#cb87-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb87-5"><a href="computer-science-data-scructures-and-algorithms.html#cb87-5" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> min_max_moving_averages(array, length):</span>
-<span id="cb87-6"><a href="computer-science-data-scructures-and-algorithms.html#cb87-6" aria-hidden="true" tabindex="-1"></a>    min_average <span class="op">=</span> <span class="bu">sum</span>(array[<span class="dv">0</span>:length])<span class="op">/</span>length</span>
-<span id="cb87-7"><a href="computer-science-data-scructures-and-algorithms.html#cb87-7" aria-hidden="true" tabindex="-1"></a>    max_average <span class="op">=</span> <span class="bu">sum</span>(array[<span class="dv">0</span>:length])<span class="op">/</span>length</span>
-<span id="cb87-8"><a href="computer-science-data-scructures-and-algorithms.html#cb87-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> i <span class="kw">in</span> <span class="bu">range</span>(<span class="dv">1</span>, <span class="bu">len</span>(array)):</span>
-<span id="cb87-9"><a href="computer-science-data-scructures-and-algorithms.html#cb87-9" aria-hidden="true" tabindex="-1"></a>        average <span class="op">=</span> <span class="bu">sum</span>(array[i:i<span class="op">+</span>length])<span class="op">/</span>length</span>
-<span id="cb87-10"><a href="computer-science-data-scructures-and-algorithms.html#cb87-10" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> average <span class="op">&lt;</span> min_average:</span>
-<span id="cb87-11"><a href="computer-science-data-scructures-and-algorithms.html#cb87-11" aria-hidden="true" tabindex="-1"></a>            min_average <span class="op">=</span> average</span>
-<span id="cb87-12"><a href="computer-science-data-scructures-and-algorithms.html#cb87-12" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> average <span class="op">&gt;</span> max_average:</span>
-<span id="cb87-13"><a href="computer-science-data-scructures-and-algorithms.html#cb87-13" aria-hidden="true" tabindex="-1"></a>            max_average <span class="op">=</span> average</span>
-<span id="cb87-14"><a href="computer-science-data-scructures-and-algorithms.html#cb87-14" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> min_average, max_average </span>
-<span id="cb87-15"><a href="computer-science-data-scructures-and-algorithms.html#cb87-15" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb87-16"><a href="computer-science-data-scructures-and-algorithms.html#cb87-16" aria-hidden="true" tabindex="-1"></a>min_max_moving_averages(J, p)</span>
-<span id="cb87-17"><a href="computer-science-data-scructures-and-algorithms.html#cb87-17" aria-hidden="true" tabindex="-1"></a>    </span></code></pre></div>
-<pre><code>## (4.0, 11.0)</code></pre>
+<div id="interactive-dsa-practice" class="section level3 hasAnchor">
+<h3>Interactive Interview Drills<a href="computer-science-data-scructures-and-algorithms.html#interactive-dsa-practice" class="anchor-section" aria-label="Anchor link to header"></a></h3>
+<p class="interactive-practice-intro">Write Python directly in the browser, use <code>Run</code> to iterate quickly, then use <code>Check answer</code> to validate your solution against example cases and edge cases. Start with the popular questions below, then work through the rest for broader repetition.</p>
+<div class="interactive-practice-controls">
+<button type="button" class="interactive-python-button" id="toggle-all-dsa-solutions" aria-expanded="false">Show all solutions</button>
 </div>
-<div id="python-function-to-express-power-sets" class="section level3 hasAnchor" number="6.1.2">
-<h3><span class="header-section-number">6.1.2</span> Python function to express power sets<a href="computer-science-data-scructures-and-algorithms.html#python-function-to-express-power-sets" class="anchor-section" aria-label="Anchor link to header"></a></h3>
-<ul>
-<li>Python</li>
-<li>Power Set</li>
-</ul>
-<p>Create a Python function that generates the power set given a set of values. For example, if you’re given the following set:</p>
-<p>set = {1, 2, 3}</p>
-<p>Your python function should return the corresponding power set (note this can be a formatted as a list of lists):</p>
-<p>power set = [[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]]</p>
+<h4 id="popular-questions">Popular Questions</h4>
+<p class="interactive-practice-intro">These first questions are included because they are commonly cited as Meta and Google-style interview problems across interview-prep aggregators. Exact percentages and ranks can change over time and depend on the source, so they are summarized here instead of repeated on each card. Sources: <a href="https://www.jointaro.com/" target="_blank" rel="noopener noreferrer">Jointaro</a> company-tagged interview pages and company-listing pages such as <a href="https://www.tutorialspoint.com/practice/create-hello-world-function.htm" target="_blank" rel="noopener noreferrer">TutorialsPoint</a>.</p>
+<div id="dsa-interactive-practice-list"></div>
+<div id="dsa-other-questions" class="section level3 hasAnchor">
+<h3>Other Questions<a href="computer-science-data-scructures-and-algorithms.html#dsa-other-questions" class="anchor-section" aria-label="Anchor link to header"></a></h3>
+<div id="dsa-other-questions-list"></div>
 </div>
-<div id="if-you-were-given-a-m-by-n-matrix-how-would-you-find-the-minimum-element-using-brute-force-algorithm" class="section level3 hasAnchor" number="6.1.3">
-<h3><span class="header-section-number">6.1.3</span> If you were given a m by n matrix how would you find the minimum element using brute force algorithm<a href="computer-science-data-scructures-and-algorithms.html#if-you-were-given-a-m-by-n-matrix-how-would-you-find-the-minimum-element-using-brute-force-algorithm" class="anchor-section" aria-label="Anchor link to header"></a></h3>
-<ul>
-<li>Python</li>
-</ul>
-<div class="sourceCode" id="cb89"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb89-1"><a href="computer-science-data-scructures-and-algorithms.html#cb89-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> typing <span class="im">import</span> List</span>
-<span id="cb89-2"><a href="computer-science-data-scructures-and-algorithms.html#cb89-2" aria-hidden="true" tabindex="-1"></a><span class="co">#python doesn&#39;t have matrices but a list of a list can be treated as a matrix </span></span>
-<span id="cb89-3"><a href="computer-science-data-scructures-and-algorithms.html#cb89-3" aria-hidden="true" tabindex="-1"></a>A <span class="op">=</span> [[<span class="dv">1</span>, <span class="dv">4</span>, <span class="dv">5</span>], </span>
-<span id="cb89-4"><a href="computer-science-data-scructures-and-algorithms.html#cb89-4" aria-hidden="true" tabindex="-1"></a>    [<span class="op">-</span><span class="dv">5</span>, <span class="dv">8</span>, <span class="dv">9</span>]]</span>
-<span id="cb89-5"><a href="computer-science-data-scructures-and-algorithms.html#cb89-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb89-6"><a href="computer-science-data-scructures-and-algorithms.html#cb89-6" aria-hidden="true" tabindex="-1"></a><span class="co">#using min</span></span>
-<span id="cb89-7"><a href="computer-science-data-scructures-and-algorithms.html#cb89-7" aria-hidden="true" tabindex="-1"></a><span class="bu">min</span>(<span class="bu">min</span>(x) <span class="cf">for</span> x <span class="kw">in</span> A)</span></code></pre></div>
-<pre><code>## -5</code></pre>
-<div class="sourceCode" id="cb91"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb91-1"><a href="computer-science-data-scructures-and-algorithms.html#cb91-1" aria-hidden="true" tabindex="-1"></a><span class="co">#brute force</span></span>
-<span id="cb91-2"><a href="computer-science-data-scructures-and-algorithms.html#cb91-2" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> find_min_in_matrix(matrix: List):</span>
-<span id="cb91-3"><a href="computer-science-data-scructures-and-algorithms.html#cb91-3" aria-hidden="true" tabindex="-1"></a>    min_element <span class="op">=</span> matrix[<span class="dv">0</span>][<span class="dv">0</span>]</span>
-<span id="cb91-4"><a href="computer-science-data-scructures-and-algorithms.html#cb91-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> sub_list <span class="kw">in</span> <span class="bu">range</span>(<span class="bu">len</span>(matrix)):</span>
-<span id="cb91-5"><a href="computer-science-data-scructures-and-algorithms.html#cb91-5" aria-hidden="true" tabindex="-1"></a>        <span class="cf">for</span> element <span class="kw">in</span> matrix[sub_list]:</span>
-<span id="cb91-6"><a href="computer-science-data-scructures-and-algorithms.html#cb91-6" aria-hidden="true" tabindex="-1"></a>            <span class="cf">if</span> (element <span class="op">&lt;</span> min_element):</span>
-<span id="cb91-7"><a href="computer-science-data-scructures-and-algorithms.html#cb91-7" aria-hidden="true" tabindex="-1"></a>                min_element <span class="op">=</span> element</span>
-<span id="cb91-8"><a href="computer-science-data-scructures-and-algorithms.html#cb91-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> min_element</span>
-<span id="cb91-9"><a href="computer-science-data-scructures-and-algorithms.html#cb91-9" aria-hidden="true" tabindex="-1"></a>        </span>
-<span id="cb91-10"><a href="computer-science-data-scructures-and-algorithms.html#cb91-10" aria-hidden="true" tabindex="-1"></a>find_min_in_matrix(A)    </span></code></pre></div>
-<pre><code>## -5</code></pre>
-</div>
-<div id="finding-the-value-closest-to-0" class="section level3 hasAnchor" number="6.1.4">
-<h3><span class="header-section-number">6.1.4</span> Finding the value closest to 0<a href="computer-science-data-scructures-and-algorithms.html#finding-the-value-closest-to-0" class="anchor-section" aria-label="Anchor link to header"></a></h3>
-<ul>
-<li>Python</li>
-<li>Data Structures</li>
-<li>Arrays</li>
-</ul>
-<p>Suppose you are given a list of Q 1D points. Write code to return the value in Q that is the closest to value j. If two values are equally close to j, return the smaller value.</p>
-<p>Example:</p>
-<p>Q = [1, -1, -5, 2, 4, -2, 1]
-j = 3</p>
-<p>Output: 2</p>
-<div class="sourceCode" id="cb93"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb93-1"><a href="computer-science-data-scructures-and-algorithms.html#cb93-1" aria-hidden="true" tabindex="-1"></a>Q <span class="op">=</span> [<span class="dv">1</span>, <span class="op">-</span><span class="dv">1</span>, <span class="op">-</span><span class="dv">5</span>, <span class="dv">2</span>, <span class="dv">4</span>, <span class="op">-</span><span class="dv">2</span>, <span class="dv">1</span>]</span>
-<span id="cb93-2"><a href="computer-science-data-scructures-and-algorithms.html#cb93-2" aria-hidden="true" tabindex="-1"></a>Q2 <span class="op">=</span> [<span class="dv">1</span>, <span class="op">-</span><span class="dv">1</span>, <span class="op">-</span><span class="dv">5</span>, <span class="dv">2</span>, <span class="dv">4</span>, <span class="op">-</span><span class="dv">2</span>, <span class="dv">1</span>]</span>
-<span id="cb93-3"><a href="computer-science-data-scructures-and-algorithms.html#cb93-3" aria-hidden="true" tabindex="-1"></a>j <span class="op">=</span> <span class="dv">3</span></span>
-<span id="cb93-4"><a href="computer-science-data-scructures-and-algorithms.html#cb93-4" aria-hidden="true" tabindex="-1"></a>j2 <span class="op">=</span> <span class="op">-</span><span class="dv">4</span></span>
-<span id="cb93-5"><a href="computer-science-data-scructures-and-algorithms.html#cb93-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb93-6"><a href="computer-science-data-scructures-and-algorithms.html#cb93-6" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> closest_value(array, target):</span>
-<span id="cb93-7"><a href="computer-science-data-scructures-and-algorithms.html#cb93-7" aria-hidden="true" tabindex="-1"></a>    differences <span class="op">=</span> {}</span>
-<span id="cb93-8"><a href="computer-science-data-scructures-and-algorithms.html#cb93-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> i <span class="kw">in</span> <span class="bu">range</span>(<span class="bu">len</span>(array)):</span>
-<span id="cb93-9"><a href="computer-science-data-scructures-and-algorithms.html#cb93-9" aria-hidden="true" tabindex="-1"></a>        differences[array[i]] <span class="op">=</span> target <span class="op">-</span> array[i]</span>
-<span id="cb93-10"><a href="computer-science-data-scructures-and-algorithms.html#cb93-10" aria-hidden="true" tabindex="-1"></a>    min_difference <span class="op">=</span> <span class="bu">min</span>([i <span class="cf">for</span> i <span class="kw">in</span> <span class="bu">list</span>(differences.values()) <span class="cf">if</span> i <span class="op">&gt;=</span> <span class="dv">0</span>])</span>
-<span id="cb93-11"><a href="computer-science-data-scructures-and-algorithms.html#cb93-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> differences.get(min_difference)</span>
-<span id="cb93-12"><a href="computer-science-data-scructures-and-algorithms.html#cb93-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb93-13"><a href="computer-science-data-scructures-and-algorithms.html#cb93-13" aria-hidden="true" tabindex="-1"></a>closest_value(Q, j)</span></code></pre></div>
-<pre><code>## 2</code></pre>
-<div class="sourceCode" id="cb95"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb95-1"><a href="computer-science-data-scructures-and-algorithms.html#cb95-1" aria-hidden="true" tabindex="-1"></a>closest_value(Q2, j2)</span></code></pre></div>
-<pre><code>## -5</code></pre>
-<p>###Points within an interval</p>
-<ul>
-<li>Python</li>
-<li>Data Structures</li>
-<li>Arrays</li>
-</ul>
-<p>Suppose you are given P, which is list of j integer intervals, where j is the number of intervals. The intervals are in a format [a, b].</p>
-<p>Given an integer z, can you return the number of overlapping intervals for point z?</p>
-<p>For example:</p>
-<p>Input:
-<code>P =  [[0, 2], [3, 7], [4, 6], [7, 8], [1 ,5]]</code>
-<code>z = 5</code>
-Output:
-<code>3</code>
-At z = 5, there are 3 intervals that overlap. The intervals are: [3, 7], [4, 6], and [1, 5]</p>
-<div class="sourceCode" id="cb97"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb97-1"><a href="computer-science-data-scructures-and-algorithms.html#cb97-1" aria-hidden="true" tabindex="-1"></a>P <span class="op">=</span>  [[<span class="dv">0</span>, <span class="dv">2</span>], [<span class="dv">3</span>, <span class="dv">7</span>], [<span class="dv">4</span>, <span class="dv">6</span>], [<span class="dv">7</span>, <span class="dv">8</span>], [<span class="dv">1</span> ,<span class="dv">5</span>]]</span>
-<span id="cb97-2"><a href="computer-science-data-scructures-and-algorithms.html#cb97-2" aria-hidden="true" tabindex="-1"></a>z <span class="op">=</span> <span class="dv">5</span></span>
-<span id="cb97-3"><a href="computer-science-data-scructures-and-algorithms.html#cb97-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb97-4"><a href="computer-science-data-scructures-and-algorithms.html#cb97-4" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> num_within_intervals(array, target):</span>
-<span id="cb97-5"><a href="computer-science-data-scructures-and-algorithms.html#cb97-5" aria-hidden="true" tabindex="-1"></a>    count <span class="op">=</span> <span class="dv">0</span></span>
-<span id="cb97-6"><a href="computer-science-data-scructures-and-algorithms.html#cb97-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> i <span class="kw">in</span> <span class="bu">range</span>(<span class="bu">len</span>(array)):</span>
-<span id="cb97-7"><a href="computer-science-data-scructures-and-algorithms.html#cb97-7" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> array[i][<span class="dv">0</span>] <span class="op">&lt;=</span> target <span class="kw">and</span> array[i][<span class="dv">1</span>] <span class="op">&gt;=</span> target:</span>
-<span id="cb97-8"><a href="computer-science-data-scructures-and-algorithms.html#cb97-8" aria-hidden="true" tabindex="-1"></a>            count <span class="op">+=</span> <span class="dv">1</span></span>
-<span id="cb97-9"><a href="computer-science-data-scructures-and-algorithms.html#cb97-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> count</span>
-<span id="cb97-10"><a href="computer-science-data-scructures-and-algorithms.html#cb97-10" aria-hidden="true" tabindex="-1"></a>        </span>
-<span id="cb97-11"><a href="computer-science-data-scructures-and-algorithms.html#cb97-11" aria-hidden="true" tabindex="-1"></a>num_within_intervals(P, z)</span></code></pre></div>
-<pre><code>## 3</code></pre>
-<pre echo="FALSE," include="FALSE"><code>### Checking whether array elements can be made equal
-
-#* Python 
-#* Data Structures 
-#* Arrays
-
-Given an array a, write a function to feed in the array elements and check whether they can all be made equal by only multiplying the numbers by 2 or 7. (you can multiply by these #s as many times as you like)
-
-If all elements can be made equal, return False, otherwise return True.
-
-Example:
-
-#Input
-a = [128, 4, 2]
-
-#Here, we can turn all elements into 128, by multiplying by 2
-#128, 4*2*2*2*2*2 = 128, 2*2*2*2*2*2*2 = 128
-
-#Output:
-#True
-
-#Input
-a = [65, 4, 2] 
-#Here, we cannot make all elements equal through multiplication by 2 or 7, 
-#so we return false
-
-#Output:
-#False
-
-
-#UNFINISHED
-# similar - https://www.geeksforgeeks.org/make-all-numbers-of-an-array-equal/
-def mult_of_2_or_7(array)-&gt;bool:
-    for i in [1,2]:
-        while array[i] &lt; array[0]:
-            array[i]
-    return True
-
-a = [65, 4, 2]
-b = [128, 4, 2]
-mult_of_2_or_7(array=a)
-mult_of_2_or_7(array=b)</code></pre>
-
 </div>
 </div>
 </div>
@@ -444,6 +301,1409 @@ mult_of_2_or_7(array=b)</code></pre>
 <script src="libs/gitbook-2.6.7/js/plugin-bookdown.js"></script>
 <script src="libs/gitbook-2.6.7/js/jquery.highlight.js"></script>
 <script src="libs/gitbook-2.6.7/js/plugin-clipboard.js"></script>
+<script src="https://cdn.jsdelivr.net/pyodide/v0.27.7/full/pyodide.js"></script>
+<script>
+(function() {
+  var questions = [
+    {
+      id: "moving-average",
+      title: "Calculate Moving Average Using Python",
+      popularity: "Sliding-window array practice with built-in example and edge-case checks.",
+      group: "other",
+      prompt: "Given a list of numbers and a window size p, return the minimum and maximum averages across all contiguous windows of size p.",
+      tags: ["Arrays", "Sliding Window"],
+      starter: [
+        "def min_max_moving_averages(array, length):",
+        "    # Return (min_average, max_average) across all windows of size length.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def min_max_moving_averages(array, length):",
+        "    if length <= 0 or length > len(array):",
+        "        raise ValueError('length must be between 1 and len(array)')",
+        "    window_sum = sum(array[:length])",
+        "    min_average = window_sum / length",
+        "    max_average = min_average",
+        "    for index in range(length, len(array)):",
+        "        window_sum += array[index] - array[index - length]",
+        "        average = window_sum / length",
+        "        min_average = min(min_average, average)",
+        "        max_average = max(max_average, average)",
+        "    return (min_average, max_average)"
+      ].join("\n"),
+      checks: [
+        "candidate = min_max_moving_averages",
+        "check_equal('example case', candidate([4, 4, 4, 9, 10, 11, 12], 3), (4.0, 11.0))",
+        "check_equal('window size one', candidate([5, -2, 7], 1), (-2.0, 7.0))",
+        "check_equal('whole array window', candidate([2, 4, 6, 8], 4), (5.0, 5.0))"
+      ].join("\n")
+    },
+    {
+      id: "power-set",
+      title: "Python Function to Express Power Sets",
+      popularity: "Subset-generation practice that works well for recursion or iterative bitmasking.",
+      group: "other",
+      prompt: "Return the power set of the given values. The result can be formatted as a list of lists.",
+      tags: ["Sets", "Recursion", "Backtracking"],
+      starter: [
+        "def power_set(values):",
+        "    # Return the power set as a list of lists.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def power_set(values):",
+        "    subsets = [[]]",
+        "    for value in values:",
+        "        subsets += [subset + [value] for subset in subsets]",
+        "    return subsets"
+      ].join("\n"),
+      checks: [
+        "candidate = power_set",
+        "check_equal('three-value set', normalize_nested(candidate([1, 2, 3])), normalize_nested([[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]]))",
+        "check_equal('empty input', normalize_nested(candidate([])), normalize_nested([[]]))",
+        "check_equal('single value', normalize_nested(candidate([9])), normalize_nested([[], [9]]))"
+      ].join("\n")
+    },
+    {
+      id: "find-min-in-matrix",
+      title: "Find the Minimum Element in a Matrix",
+      popularity: "Simple nested-loop brute-force practice on matrix traversal.",
+      group: "other",
+      prompt: "Given an m by n matrix, return the minimum element using a brute-force algorithm.",
+      tags: ["Matrices", "Brute Force"],
+      starter: [
+        "def find_min_in_matrix(matrix):",
+        "    # Return the minimum element in the matrix.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def find_min_in_matrix(matrix):",
+        "    min_element = matrix[0][0]",
+        "    for row in matrix:",
+        "        for value in row:",
+        "            if value < min_element:",
+        "                min_element = value",
+        "    return min_element"
+      ].join("\n"),
+      checks: [
+        "candidate = find_min_in_matrix",
+        "check_equal('example case', candidate([[1, 4, 5], [-5, 8, 9]]), -5)",
+        "check_equal('single row', candidate([[3, 2, 7, 1]]), 1)",
+        "check_equal('all positive matrix', candidate([[9, 8], [7, 6]]), 6)"
+      ].join("\n")
+    },
+    {
+      id: "closest-value",
+      title: "Finding the Value Closest to 0",
+      popularity: "Array scan practice with a tie-breaking rule.",
+      group: "other",
+      prompt: "Given a list of values Q and target j, return the value closest to j. If two values are equally close, return the smaller value.",
+      tags: ["Arrays", "Comparison"],
+      starter: [
+        "def closest_value(array, target):",
+        "    # Return the value closest to target; break ties toward the smaller value.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def closest_value(array, target):",
+        "    best = array[0]",
+        "    for value in array[1:]:",
+        "        current_gap = abs(value - target)",
+        "        best_gap = abs(best - target)",
+        "        if current_gap < best_gap or (current_gap == best_gap and value < best):",
+        "            best = value",
+        "    return best"
+      ].join("\n"),
+      checks: [
+        "candidate = closest_value",
+        "check_equal('example case', candidate([1, -1, -5, 2, 4, -2, 1], 3), 2)",
+        "check_equal('negative target', candidate([1, -1, -5, 2, 4, -2, 1], -4), -5)",
+        "check_equal('tie breaks smaller', candidate([2, 4], 3), 2)"
+      ].join("\n")
+    },
+    {
+      id: "points-within-interval",
+      title: "Points Within an Interval",
+      popularity: "Interval-counting practice with inclusive endpoints.",
+      group: "other",
+      prompt: "Given a list of inclusive integer intervals [a, b] and an integer z, return how many intervals overlap z.",
+      tags: ["Intervals", "Arrays"],
+      starter: [
+        "def num_within_intervals(array, target):",
+        "    # Return the number of intervals that contain target.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def num_within_intervals(array, target):",
+        "    count = 0",
+        "    for start, end in array:",
+        "        if start <= target <= end:",
+        "            count += 1",
+        "    return count"
+      ].join("\n"),
+      checks: [
+        "candidate = num_within_intervals",
+        "check_equal('example case', candidate([[0, 2], [3, 7], [4, 6], [7, 8], [1, 5]], 5), 3)",
+        "check_equal('inclusive endpoint', candidate([[1, 3], [3, 5], [6, 8]], 3), 2)",
+        "check_equal('no overlaps', candidate([[1, 2], [4, 5]], 3), 0)"
+      ].join("\n")
+    },
+    {
+      id: "two-sum",
+      title: "Two Sum",
+      prompt: "Given an array of integers and a target, return the indices of the two numbers that add up to the target. Assume exactly one valid answer and do not reuse the same element twice.",
+      tags: ["Arrays", "Hash Map"],
+      starter: [
+        "def two_sum(nums, target):",
+        "    # Return the indices of the two values that sum to target.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def two_sum(nums, target):",
+        "    seen = {}",
+        "    for index, value in enumerate(nums):",
+        "        needed = target - value",
+        "        if needed in seen:",
+        "            return [seen[needed], index]",
+        "        seen[value] = index"
+      ].join("\n"),
+      checks: [
+        "candidate = two_sum",
+        "check_true(",
+        "    'example case',",
+        "    sorted(normalize_pair(candidate([2, 7, 11, 15], 9))) == [0, 1],",
+        "    actual=normalize_pair(candidate([2, 7, 11, 15], 9)),",
+        "    expected='indices [0, 1]'",
+        ")",
+        "check_true(",
+        "    'duplicate values',",
+        "    sorted(normalize_pair(candidate([3, 3], 6))) == [0, 1],",
+        "    actual=normalize_pair(candidate([3, 3], 6)),",
+        "    expected='indices [0, 1]'",
+        ")",
+        "check_true(",
+        "    'negative values',",
+        "    sorted(normalize_pair(candidate([-3, 4, 3, 90], 0))) == [0, 2],",
+        "    actual=normalize_pair(candidate([-3, 4, 3, 90], 0)),",
+        "    expected='indices [0, 2]'",
+        ")"
+      ].join("\n")
+    },
+    {
+      id: "merge-sorted-array",
+      title: "Merge Sorted Array",
+      prompt: "Merge nums2 into nums1 as one sorted array. Assume nums1 has length m + n, with the last n slots available for the merge. Returning nums1 is fine, but mutating nums1 in place is the main requirement.",
+      tags: ["Arrays", "Two Pointers"],
+      starter: [
+        "def merge_sorted_array(nums1, m, nums2, n):",
+        "    # Mutate nums1 in place and optionally return it.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def merge_sorted_array(nums1, m, nums2, n):",
+        "    write = m + n - 1",
+        "    i = m - 1",
+        "    j = n - 1",
+        "    while j >= 0:",
+        "        if i >= 0 and nums1[i] > nums2[j]:",
+        "            nums1[write] = nums1[i]",
+        "            i -= 1",
+        "        else:",
+        "            nums1[write] = nums2[j]",
+        "            j -= 1",
+        "        write -= 1",
+        "    return nums1"
+      ].join("\n"),
+      checks: [
+        "candidate = merge_sorted_array",
+        "run_merge_case('example case', candidate, [1, 2, 3, 0, 0, 0], 3, [2, 5, 6], 3, [1, 2, 2, 3, 5, 6])",
+        "run_merge_case('nums2 empty', candidate, [1], 1, [], 0, [1])",
+        "run_merge_case('nums1 empty payload', candidate, [0], 0, [1], 1, [1])"
+      ].join("\n")
+    },
+    {
+      id: "hello-world-function",
+      title: "Create Hello World Function",
+      prompt: "Return a function that always returns the string 'Hello World', regardless of any arguments passed to it.",
+      tags: ["Functions", "Closures"],
+      starter: [
+        "def create_hello_world():",
+        "    # Return a function that ignores its inputs.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def create_hello_world():",
+        "    def inner(*args, **kwargs):",
+        "        return 'Hello World'",
+        "    return inner"
+      ].join("\n"),
+      checks: [
+        "factory = create_hello_world",
+        "fn = factory()",
+        "check_equal('returns callable output', fn(), 'Hello World')",
+        "check_equal('ignores positional args', fn(1, 2, 3), 'Hello World')",
+        "check_equal(\"ignores mixed args\", fn('x', flag=True), 'Hello World')"
+      ].join("\n")
+    },
+    {
+      id: "basic-calculator-ii",
+      title: "Basic Calculator II",
+      prompt: "Evaluate a string expression containing non-negative integers, '+', '-', '*', '/', and spaces. Division should truncate toward zero.",
+      tags: ["Strings", "Stack"],
+      starter: [
+        "def calculate(s):",
+        "    # Evaluate the expression and return the integer result.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def calculate(s):",
+        "    stack = []",
+        "    number = 0",
+        "    operator = '+'",
+        "    for char in s + '+':",
+        "        if char.isdigit():",
+        "            number = number * 10 + int(char)",
+        "        elif char == ' ':",
+        "            continue",
+        "        else:",
+        "            if operator == '+':",
+        "                stack.append(number)",
+        "            elif operator == '-':",
+        "                stack.append(-number)",
+        "            elif operator == '*':",
+        "                stack.append(stack.pop() * number)",
+        "            else:",
+        "                stack.append(int(stack.pop() / number))",
+        "            operator = char",
+        "            number = 0",
+        "    return sum(stack)"
+      ].join("\n"),
+      checks: [
+        "candidate = calculate",
+        "check_equal('operator precedence', candidate('3+2*2'), 7)",
+        "check_equal('truncate division', candidate(' 3/2 '), 1)",
+        "check_equal('mixed spaces and division', candidate(' 3+5 / 2 '), 5)",
+        "check_equal('truncate toward zero with subtraction', candidate('14-3/2'), 13)",
+        "check_equal('longer expression', candidate('100/10*5+7-3'), 54)"
+      ].join("\n")
+    },
+    {
+      id: "find-peak-element",
+      title: "Find Peak Element",
+      prompt: "Return the index of any peak element. A peak is strictly greater than its neighbors; values outside the array can be treated as negative infinity.",
+      tags: ["Arrays", "Binary Search"],
+      starter: [
+        "def find_peak_element(nums):",
+        "    # Return the index of any valid peak element.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def find_peak_element(nums):",
+        "    left = 0",
+        "    right = len(nums) - 1",
+        "    while left < right:",
+        "        mid = (left + right) // 2",
+        "        if nums[mid] < nums[mid + 1]:",
+        "            left = mid + 1",
+        "        else:",
+        "            right = mid",
+        "    return left"
+      ].join("\n"),
+      checks: [
+        "candidate = find_peak_element",
+        "index = candidate([1, 2, 3, 1])",
+        "check_true('single peak example', is_peak([1, 2, 3, 1], index), actual=index, expected='valid peak index')",
+        "index = candidate([1, 2, 1, 3, 5, 6, 4])",
+        "check_true('multiple peaks allowed', is_peak([1, 2, 1, 3, 5, 6, 4], index), actual=index, expected='valid peak index')",
+        "check_equal('single element array', candidate([1]), 0)",
+        "check_equal('peak at boundary', candidate([2, 1]), 0)"
+      ].join("\n")
+    },
+    {
+      id: "subarray-sum-equals-k",
+      title: "Subarray Sum Equals K",
+      prompt: "Return the total count of continuous subarrays whose sum equals k.",
+      tags: ["Arrays", "Prefix Sum", "Hash Map"],
+      starter: [
+        "def subarray_sum(nums, k):",
+        "    # Return the number of continuous subarrays that sum to k.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def subarray_sum(nums, k):",
+        "    counts = {0: 1}",
+        "    prefix = 0",
+        "    total = 0",
+        "    for value in nums:",
+        "        prefix += value",
+        "        total += counts.get(prefix - k, 0)",
+        "        counts[prefix] = counts.get(prefix, 0) + 1",
+        "    return total"
+      ].join("\n"),
+      checks: [
+        "candidate = subarray_sum",
+        "check_equal('basic example', candidate([1, 1, 1], 2), 2)",
+        "check_equal('multiple windows', candidate([1, 2, 3], 3), 2)",
+        "check_equal('handles negatives and zero', candidate([1, -1, 0], 0), 3)",
+        "check_equal('all zeros edge case', candidate([0, 0, 0], 0), 6)"
+      ].join("\n")
+    },
+    {
+      id: "merge-intervals",
+      title: "Merge Intervals",
+      prompt: "Merge all overlapping intervals and return the condensed list of intervals.",
+      tags: ["Intervals", "Sorting"],
+      starter: [
+        "def merge_intervals(intervals):",
+        "    # Return a merged list of overlapping intervals.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def merge_intervals(intervals):",
+        "    if not intervals:",
+        "        return []",
+        "    intervals.sort(key=lambda pair: pair[0])",
+        "    merged = [intervals[0][:]]",
+        "    for start, end in intervals[1:]:",
+        "        last = merged[-1]",
+        "        if start <= last[1]:",
+        "            last[1] = max(last[1], end)",
+        "        else:",
+        "            merged.append([start, end])",
+        "    return merged"
+      ].join("\n"),
+      checks: [
+        "candidate = merge_intervals",
+        "check_equal('basic merge', candidate([[1, 3], [2, 6], [8, 10], [15, 18]]), [[1, 6], [8, 10], [15, 18]])",
+        "check_equal('touching intervals merge', candidate([[1, 4], [4, 5]]), [[1, 5]])",
+        "check_equal('unsorted input', candidate([[5, 7], [1, 3], [2, 4]]), [[1, 4], [5, 7]])"
+      ].join("\n")
+    },
+    {
+      id: "merge-strings-alternately",
+      title: "Merge Strings Alternately",
+      prompt: "Merge two strings by alternating characters, then append the remainder from the longer string.",
+      tags: ["Strings", "Two Pointers"],
+      starter: [
+        "def merge_alternately(word1, word2):",
+        "    # Return the alternating merge of the two strings.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def merge_alternately(word1, word2):",
+        "    pieces = []",
+        "    limit = max(len(word1), len(word2))",
+        "    for index in range(limit):",
+        "        if index < len(word1):",
+        "            pieces.append(word1[index])",
+        "        if index < len(word2):",
+        "            pieces.append(word2[index])",
+        "    return ''.join(pieces)"
+      ].join("\n"),
+      checks: [
+        "candidate = merge_alternately",
+        "check_equal('same length strings', candidate('abc', 'pqr'), 'apbqcr')",
+        "check_equal('second string longer', candidate('ab', 'pqrs'), 'apbqrs')",
+        "check_equal('first string longer', candidate('abcd', 'pq'), 'apbqcd')",
+        "check_equal('empty string edge case', candidate('', 'xyz'), 'xyz')"
+      ].join("\n")
+    },
+    {
+      id: "add-two-numbers",
+      title: "Add Two Numbers",
+      prompt: "Each linked list stores a non-negative integer in reverse order, one digit per node. Return the sum as a linked list in the same reverse-order format.",
+      tags: ["Linked List", "Math"],
+      starter: [
+        "def add_two_numbers(l1, l2):",
+        "    # Return the summed linked list in reverse digit order.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def add_two_numbers(l1, l2):",
+        "    dummy = ListNode(0)",
+        "    tail = dummy",
+        "    carry = 0",
+        "    while l1 or l2 or carry:",
+        "        value1 = l1.val if l1 else 0",
+        "        value2 = l2.val if l2 else 0",
+        "        carry, digit = divmod(value1 + value2 + carry, 10)",
+        "        tail.next = ListNode(digit)",
+        "        tail = tail.next",
+        "        l1 = l1.next if l1 else None",
+        "        l2 = l2.next if l2 else None",
+        "    return dummy.next"
+      ].join("\n"),
+      setup: [
+        "class ListNode:",
+        "    def __init__(self, val=0, next=None):",
+        "        self.val = val",
+        "        self.next = next",
+        "",
+        "def build_linked_list(values):",
+        "    dummy = ListNode()",
+        "    tail = dummy",
+        "    for value in values:",
+        "        tail.next = ListNode(value)",
+        "        tail = tail.next",
+        "    return dummy.next",
+        "",
+        "def linked_list_to_list(node):",
+        "    values = []",
+        "    while node is not None:",
+        "        values.append(node.val)",
+        "        node = node.next",
+        "    return values"
+      ].join("\n"),
+      checks: [
+        "candidate = add_two_numbers",
+        "result = candidate(build_linked_list([2, 4, 3]), build_linked_list([5, 6, 4]))",
+        "check_equal('basic addition', linked_list_to_list(result), [7, 0, 8])",
+        "result = candidate(build_linked_list([0]), build_linked_list([0]))",
+        "check_equal('zero plus zero', linked_list_to_list(result), [0])",
+        "result = candidate(build_linked_list([9, 9, 9, 9, 9, 9, 9]), build_linked_list([9, 9, 9, 9]))",
+        "check_equal('carry chain edge case', linked_list_to_list(result), [8, 9, 9, 9, 0, 0, 0, 1])"
+      ].join("\n")
+    },
+    {
+      id: "lowest-common-ancestor",
+      title: "Lowest Common Ancestor of a Binary Tree",
+      prompt: "Given a binary tree and two nodes in the tree, return their lowest common ancestor.",
+      tags: ["Trees", "DFS", "Recursion"],
+      starter: [
+        "def lowest_common_ancestor(root, p, q):",
+        "    # Return the lowest common ancestor node.",
+        "    pass"
+      ].join("\n"),
+      solution: [
+        "def lowest_common_ancestor(root, p, q):",
+        "    if root is None or root is p or root is q:",
+        "        return root",
+        "    left = lowest_common_ancestor(root.left, p, q)",
+        "    right = lowest_common_ancestor(root.right, p, q)",
+        "    if left and right:",
+        "        return root",
+        "    return left or right"
+      ].join("\n"),
+      setup: [
+        "class TreeNode:",
+        "    def __init__(self, val=0, left=None, right=None):",
+        "        self.val = val",
+        "        self.left = left",
+        "        self.right = right",
+        "",
+        "def build_tree(values):",
+        "    if not values:",
+        "        return None",
+        "    nodes = [None if value is None else TreeNode(value) for value in values]",
+        "    child_index = 1",
+        "    for node in nodes:",
+        "        if node is None:",
+        "            continue",
+        "        if child_index < len(nodes):",
+        "            node.left = nodes[child_index]",
+        "            child_index += 1",
+        "        if child_index < len(nodes):",
+        "            node.right = nodes[child_index]",
+        "            child_index += 1",
+        "    return nodes[0]",
+        "",
+        "def find_node(root, target):",
+        "    if root is None:",
+        "        return None",
+        "    if root.val == target:",
+        "        return root",
+        "    left = find_node(root.left, target)",
+        "    if left is not None:",
+        "        return left",
+        "    return find_node(root.right, target)"
+      ].join("\n"),
+      checks: [
+        "candidate = lowest_common_ancestor",
+        "root = build_tree([3, 5, 1, 6, 2, 0, 8, None, None, 7, 4])",
+        "result = candidate(root, find_node(root, 5), find_node(root, 1))",
+        "check_equal('split across root', result.val if result else None, 3)",
+        "root = build_tree([3, 5, 1, 6, 2, 0, 8, None, None, 7, 4])",
+        "result = candidate(root, find_node(root, 5), find_node(root, 4))",
+        "check_equal('ancestor can be one input node', result.val if result else None, 5)",
+        "root = build_tree([1, 2])",
+        "result = candidate(root, find_node(root, 1), find_node(root, 2))",
+        "check_equal('small tree edge case', result.val if result else None, 1)"
+      ].join("\n")
+    }
+  ];
+
+  var questionMeta = {
+    "moving-average": {
+      bruteForceBigO: "Time O(n * p), Space O(1)",
+      optimizedBigO: "Time O(n), Space O(1)",
+      bruteForce: [
+        "def min_max_moving_averages(array, length):",
+        "    if length <= 0 or length > len(array):",
+        "        raise ValueError('length must be between 1 and len(array)')",
+        "    averages = []",
+        "    for start in range(len(array) - length + 1):",
+        "        averages.append(sum(array[start:start + length]) / length)",
+        "    return (min(averages), max(averages))"
+      ].join("\n"),
+      examples: [
+        {input: "array = [4, 4, 4, 9, 10, 11, 12], p = 3", output: "(4.0, 11.0)"},
+        {input: "array = [5, -2, 7], p = 1", output: "(-2.0, 7.0)"},
+        {input: "array = [2, 4, 6, 8], p = 4", output: "(5.0, 5.0)"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# array = [4, 4, 4, 9, 10, 11, 12]", "# p = 3", "# min_max_moving_averages(array, p)"],
+        ["# Example 2", "# array = [5, -2, 7]", "# p = 1", "# min_max_moving_averages(array, p)"],
+        ["# Example 3", "# array = [2, 4, 6, 8]", "# p = 4", "# min_max_moving_averages(array, p)"]
+      ]
+    },
+    "power-set": {
+      bruteForceBigO: "Time O(n * 2^n), Space O(n * 2^n)",
+      optimizedBigO: "Time O(n * 2^n), Space O(n * 2^n)",
+      bruteForce: [
+        "def power_set(values):",
+        "    subsets = []",
+        "    total_masks = 1 << len(values)",
+        "    for mask in range(total_masks):",
+        "        current = []",
+        "        for index in range(len(values)):",
+        "            if mask & (1 << index):",
+        "                current.append(values[index])",
+        "        subsets.append(current)",
+        "    return subsets"
+      ].join("\n"),
+      examples: [
+        {input: "values = [1, 2, 3]", output: "[[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]]"},
+        {input: "values = []", output: "[[]]"},
+        {input: "values = [9]", output: "[[], [9]]"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# values = [1, 2, 3]", "# power_set(values)"],
+        ["# Example 2", "# values = []", "# power_set(values)"],
+        ["# Example 3", "# values = [9]", "# power_set(values)"]
+      ]
+    },
+    "find-min-in-matrix": {
+      bruteForceBigO: "Time O(m * n), Space O(1)",
+      optimizedBigO: "Time O(m * n), Space O(1)",
+      bruteForce: [
+        "def find_min_in_matrix(matrix):",
+        "    min_element = matrix[0][0]",
+        "    for row_index in range(len(matrix)):",
+        "        for col_index in range(len(matrix[row_index])):",
+        "            value = matrix[row_index][col_index]",
+        "            if value < min_element:",
+        "                min_element = value",
+        "    return min_element"
+      ].join("\n"),
+      examples: [
+        {input: "matrix = [[1, 4, 5], [-5, 8, 9]]", output: "-5"},
+        {input: "matrix = [[3, 2, 7, 1]]", output: "1"},
+        {input: "matrix = [[9, 8], [7, 6]]", output: "6"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# matrix = [[1, 4, 5], [-5, 8, 9]]", "# find_min_in_matrix(matrix)"],
+        ["# Example 2", "# matrix = [[3, 2, 7, 1]]", "# find_min_in_matrix(matrix)"],
+        ["# Example 3", "# matrix = [[9, 8], [7, 6]]", "# find_min_in_matrix(matrix)"]
+      ]
+    },
+    "closest-value": {
+      bruteForceBigO: "Time O(n log n), Space O(n)",
+      optimizedBigO: "Time O(n), Space O(1)",
+      bruteForce: [
+        "def closest_value(array, target):",
+        "    ranked = sorted(array, key=lambda value: (abs(value - target), value))",
+        "    return ranked[0]"
+      ].join("\n"),
+      examples: [
+        {input: "Q = [1, -1, -5, 2, 4, -2, 1], j = 3", output: "2"},
+        {input: "Q = [1, -1, -5, 2, 4, -2, 1], j = -4", output: "-5"},
+        {input: "Q = [2, 4], j = 3", output: "2"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# array = [1, -1, -5, 2, 4, -2, 1]", "# target = 3", "# closest_value(array, target)"],
+        ["# Example 2", "# array = [1, -1, -5, 2, 4, -2, 1]", "# target = -4", "# closest_value(array, target)"],
+        ["# Example 3", "# array = [2, 4]", "# target = 3", "# closest_value(array, target)"]
+      ]
+    },
+    "points-within-interval": {
+      bruteForceBigO: "Time O(n), Space O(1)",
+      optimizedBigO: "Time O(n), Space O(1)",
+      bruteForce: [
+        "def num_within_intervals(array, target):",
+        "    count = 0",
+        "    for interval in array:",
+        "        if interval[0] <= target and interval[1] >= target:",
+        "            count += 1",
+        "    return count"
+      ].join("\n"),
+      examples: [
+        {input: "P = [[0, 2], [3, 7], [4, 6], [7, 8], [1, 5]], z = 5", output: "3"},
+        {input: "P = [[1, 3], [3, 5], [6, 8]], z = 3", output: "2"},
+        {input: "P = [[1, 2], [4, 5]], z = 3", output: "0"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# intervals = [[0, 2], [3, 7], [4, 6], [7, 8], [1, 5]]", "# target = 5", "# num_within_intervals(intervals, target)"],
+        ["# Example 2", "# intervals = [[1, 3], [3, 5], [6, 8]]", "# target = 3", "# num_within_intervals(intervals, target)"],
+        ["# Example 3", "# intervals = [[1, 2], [4, 5]]", "# target = 3", "# num_within_intervals(intervals, target)"]
+      ]
+    },
+    "two-sum": {
+      bruteForceBigO: "Time O(n^2), Space O(1)",
+      optimizedBigO: "Time O(n), Space O(n)",
+      bruteForce: [
+        "def two_sum(nums, target):",
+        "    for i in range(len(nums)):",
+        "        for j in range(i + 1, len(nums)):",
+        "            if nums[i] + nums[j] == target:",
+        "                return [i, j]"
+      ].join("\n"),
+      examples: [
+        {input: "nums = [2, 7, 11, 15], target = 9", output: "[0, 1]"},
+        {input: "nums = [3, 3], target = 6", output: "[0, 1]"},
+        {input: "nums = [-3, 4, 3, 90], target = 0", output: "[0, 2]"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# nums = [2, 7, 11, 15]", "# target = 9", "# two_sum(nums, target)"],
+        ["# Example 2", "# nums = [3, 3]", "# target = 6", "# two_sum(nums, target)"],
+        ["# Example 3", "# nums = [-3, 4, 3, 90]", "# target = 0", "# two_sum(nums, target)"]
+      ]
+    },
+    "merge-sorted-array": {
+      bruteForceBigO: "Time O((m + n) log(m + n)), Space O(m + n)",
+      optimizedBigO: "Time O(m + n), Space O(1)",
+      bruteForce: [
+        "def merge_sorted_array(nums1, m, nums2, n):",
+        "    merged = nums1[:m] + nums2[:n]",
+        "    merged.sort()",
+        "    nums1[:m + n] = merged",
+        "    return nums1"
+      ].join("\n"),
+      examples: [
+        {input: "nums1 = [1, 2, 3, 0, 0, 0], m = 3, nums2 = [2, 5, 6], n = 3", output: "[1, 2, 2, 3, 5, 6]"},
+        {input: "nums1 = [1], m = 1, nums2 = [], n = 0", output: "[1]"},
+        {input: "nums1 = [0], m = 0, nums2 = [1], n = 1", output: "[1]"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# nums1 = [1, 2, 3, 0, 0, 0]", "# m = 3", "# nums2 = [2, 5, 6]", "# n = 3", "# merge_sorted_array(nums1, m, nums2, n)", "# nums1"],
+        ["# Example 2", "# nums1 = [1]", "# m = 1", "# nums2 = []", "# n = 0", "# merge_sorted_array(nums1, m, nums2, n)", "# nums1"],
+        ["# Example 3", "# nums1 = [0]", "# m = 0", "# nums2 = [1]", "# n = 1", "# merge_sorted_array(nums1, m, nums2, n)", "# nums1"]
+      ]
+    },
+    "hello-world-function": {
+      bruteForceBigO: "Time O(1), Space O(1)",
+      optimizedBigO: "Time O(1), Space O(1)",
+      bruteForce: [
+        "def create_hello_world():",
+        "    return lambda *args, **kwargs: 'Hello World'"
+      ].join("\n"),
+      examples: [
+        {input: "fn = create_hello_world(); fn()", output: "'Hello World'"},
+        {input: "fn = create_hello_world(); fn(1, 2, 3)", output: "'Hello World'"},
+        {input: "fn = create_hello_world(); fn('x', flag=True)", output: "'Hello World'"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# fn = create_hello_world()", "# fn()"],
+        ["# Example 2", "# fn = create_hello_world()", "# fn(1, 2, 3)"],
+        ["# Example 3", "# fn = create_hello_world()", "# fn('x', flag=True)"]
+      ]
+    },
+    "basic-calculator-ii": {
+      bruteForceBigO: "Time O(n), Space O(n)",
+      optimizedBigO: "Time O(n), Space O(n)",
+      bruteForce: [
+        "def calculate(s):",
+        "    tokens = []",
+        "    number = ''",
+        "    for char in s:",
+        "        if char == ' ':",
+        "            continue",
+        "        if char.isdigit():",
+        "            number += char",
+        "        else:",
+        "            tokens.append(int(number))",
+        "            tokens.append(char)",
+        "            number = ''",
+        "    tokens.append(int(number))",
+        "",
+        "    stack = [tokens[0]]",
+        "    index = 1",
+        "    while index < len(tokens):",
+        "        operator = tokens[index]",
+        "        value = tokens[index + 1]",
+        "        if operator == '*':",
+        "            stack[-1] *= value",
+        "        elif operator == '/':",
+        "            stack[-1] = int(stack[-1] / value)",
+        "        else:",
+        "            stack.extend([operator, value])",
+        "        index += 2",
+        "",
+        "    result = stack[0]",
+        "    index = 1",
+        "    while index < len(stack):",
+        "        operator = stack[index]",
+        "        value = stack[index + 1]",
+        "        result = result + value if operator == '+' else result - value",
+        "        index += 2",
+        "    return result"
+      ].join("\n"),
+      examples: [
+        {input: 's = "3+2*2"', output: "7"},
+        {input: 's = " 3/2 "', output: "1"},
+        {input: 's = " 3+5 / 2 "', output: "5"}
+      ],
+      starterExamples: [
+        ["# Example 1", '# s = "3+2*2"', "# calculate(s)"],
+        ["# Example 2", '# s = " 3/2 "', "# calculate(s)"],
+        ["# Example 3", '# s = " 3+5 / 2 "', "# calculate(s)"]
+      ]
+    },
+    "find-peak-element": {
+      bruteForceBigO: "Time O(n), Space O(1)",
+      optimizedBigO: "Time O(log n), Space O(1)",
+      bruteForce: [
+        "def find_peak_element(nums):",
+        "    for index, value in enumerate(nums):",
+        "        left = nums[index - 1] if index > 0 else float('-inf')",
+        "        right = nums[index + 1] if index < len(nums) - 1 else float('-inf')",
+        "        if value > left and value > right:",
+        "            return index"
+      ].join("\n"),
+      examples: [
+        {input: "nums = [1, 2, 3, 1]", output: "2"},
+        {input: "nums = [1, 2, 1, 3, 5, 6, 4]", output: "1 or 5"},
+        {input: "nums = [2, 1]", output: "0"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# nums = [1, 2, 3, 1]", "# find_peak_element(nums)"],
+        ["# Example 2", "# nums = [1, 2, 1, 3, 5, 6, 4]", "# find_peak_element(nums)"],
+        ["# Example 3", "# nums = [2, 1]", "# find_peak_element(nums)"]
+      ]
+    },
+    "subarray-sum-equals-k": {
+      bruteForceBigO: "Time O(n^2), Space O(1)",
+      optimizedBigO: "Time O(n), Space O(n)",
+      bruteForce: [
+        "def subarray_sum(nums, k):",
+        "    total = 0",
+        "    for start in range(len(nums)):",
+        "        current_sum = 0",
+        "        for end in range(start, len(nums)):",
+        "            current_sum += nums[end]",
+        "            if current_sum == k:",
+        "                total += 1",
+        "    return total"
+      ].join("\n"),
+      examples: [
+        {input: "nums = [1, 1, 1], k = 2", output: "2"},
+        {input: "nums = [1, 2, 3], k = 3", output: "2"},
+        {input: "nums = [0, 0, 0], k = 0", output: "6"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# nums = [1, 1, 1]", "# k = 2", "# subarray_sum(nums, k)"],
+        ["# Example 2", "# nums = [1, 2, 3]", "# k = 3", "# subarray_sum(nums, k)"],
+        ["# Example 3", "# nums = [0, 0, 0]", "# k = 0", "# subarray_sum(nums, k)"]
+      ]
+    },
+    "merge-intervals": {
+      bruteForceBigO: "Time O(n^2), Space O(n)",
+      optimizedBigO: "Time O(n log n), Space O(n)",
+      bruteForce: [
+        "def merge_intervals(intervals):",
+        "    merged = [interval[:] for interval in intervals]",
+        "    changed = True",
+        "    while changed:",
+        "        changed = False",
+        "        next_round = []",
+        "        while merged:",
+        "            start, end = merged.pop()",
+        "            did_merge = False",
+        "            for index, (other_start, other_end) in enumerate(merged):",
+        "                if not (end < other_start or other_end < start):",
+        "                    merged[index] = [min(start, other_start), max(end, other_end)]",
+        "                    changed = True",
+        "                    did_merge = True",
+        "                    break",
+        "            if not did_merge:",
+        "                next_round.append([start, end])",
+        "        merged = next_round",
+        "    return sorted(merged)"
+      ].join("\n"),
+      examples: [
+        {input: "intervals = [[1, 3], [2, 6], [8, 10], [15, 18]]", output: "[[1, 6], [8, 10], [15, 18]]"},
+        {input: "intervals = [[1, 4], [4, 5]]", output: "[[1, 5]]"},
+        {input: "intervals = [[5, 7], [1, 3], [2, 4]]", output: "[[1, 4], [5, 7]]"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# intervals = [[1, 3], [2, 6], [8, 10], [15, 18]]", "# merge_intervals(intervals)"],
+        ["# Example 2", "# intervals = [[1, 4], [4, 5]]", "# merge_intervals(intervals)"],
+        ["# Example 3", "# intervals = [[5, 7], [1, 3], [2, 4]]", "# merge_intervals(intervals)"]
+      ]
+    },
+    "merge-strings-alternately": {
+      bruteForceBigO: "Time O(n + m), Space O(n + m)",
+      optimizedBigO: "Time O(n + m), Space O(n + m)",
+      bruteForce: [
+        "def merge_alternately(word1, word2):",
+        "    answer = ''",
+        "    limit = max(len(word1), len(word2))",
+        "    for index in range(limit):",
+        "        if index < len(word1):",
+        "            answer += word1[index]",
+        "        if index < len(word2):",
+        "            answer += word2[index]",
+        "    return answer"
+      ].join("\n"),
+      examples: [
+        {input: "word1 = 'abc', word2 = 'pqr'", output: "'apbqcr'"},
+        {input: "word1 = 'ab', word2 = 'pqrs'", output: "'apbqrs'"},
+        {input: "word1 = '', word2 = 'xyz'", output: "'xyz'"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# word1 = 'abc'", "# word2 = 'pqr'", "# merge_alternately(word1, word2)"],
+        ["# Example 2", "# word1 = 'ab'", "# word2 = 'pqrs'", "# merge_alternately(word1, word2)"],
+        ["# Example 3", "# word1 = ''", "# word2 = 'xyz'", "# merge_alternately(word1, word2)"]
+      ]
+    },
+    "add-two-numbers": {
+      bruteForceBigO: "Time O(n + m), Space O(max(n, m))",
+      optimizedBigO: "Time O(n + m), Space O(max(n, m))",
+      bruteForce: [
+        "def add_two_numbers(l1, l2):",
+        "    multiplier = 1",
+        "    first = 0",
+        "    second = 0",
+        "    node = l1",
+        "    while node:",
+        "        first += node.val * multiplier",
+        "        multiplier *= 10",
+        "        node = node.next",
+        "    multiplier = 1",
+        "    node = l2",
+        "    while node:",
+        "        second += node.val * multiplier",
+        "        multiplier *= 10",
+        "        node = node.next",
+        "    total = str(first + second)[::-1]",
+        "    dummy = ListNode()",
+        "    tail = dummy",
+        "    for digit in total:",
+        "        tail.next = ListNode(int(digit))",
+        "        tail = tail.next",
+        "    return dummy.next"
+      ].join("\n"),
+      examples: [
+        {input: "l1 = [2, 4, 3], l2 = [5, 6, 4]", output: "[7, 0, 8]"},
+        {input: "l1 = [0], l2 = [0]", output: "[0]"},
+        {input: "l1 = [9, 9, 9, 9, 9, 9, 9], l2 = [9, 9, 9, 9]", output: "[8, 9, 9, 9, 0, 0, 0, 1]"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# l1 = build_linked_list([2, 4, 3])", "# l2 = build_linked_list([5, 6, 4])", "# linked_list_to_list(add_two_numbers(l1, l2))"],
+        ["# Example 2", "# l1 = build_linked_list([0])", "# l2 = build_linked_list([0])", "# linked_list_to_list(add_two_numbers(l1, l2))"],
+        ["# Example 3", "# l1 = build_linked_list([9, 9, 9, 9, 9, 9, 9])", "# l2 = build_linked_list([9, 9, 9, 9])", "# linked_list_to_list(add_two_numbers(l1, l2))"]
+      ]
+    },
+    "lowest-common-ancestor": {
+      bruteForceBigO: "Time O(n), Space O(n)",
+      optimizedBigO: "Time O(n), Space O(h)",
+      bruteForce: [
+        "def lowest_common_ancestor(root, p, q):",
+        "    parents = {root: None}",
+        "    stack = [root]",
+        "    while p not in parents or q not in parents:",
+        "        node = stack.pop()",
+        "        if node.left:",
+        "            parents[node.left] = node",
+        "            stack.append(node.left)",
+        "        if node.right:",
+        "            parents[node.right] = node",
+        "            stack.append(node.right)",
+        "    ancestors = set()",
+        "    while p is not None:",
+        "        ancestors.add(p)",
+        "        p = parents[p]",
+        "    while q not in ancestors:",
+        "        q = parents[q]",
+        "    return q"
+      ].join("\n"),
+      examples: [
+        {input: "root = [3,5,1,6,2,0,8,null,null,7,4], p = 5, q = 1", output: "3"},
+        {input: "root = [3,5,1,6,2,0,8,null,null,7,4], p = 5, q = 4", output: "5"},
+        {input: "root = [1,2], p = 1, q = 2", output: "1"}
+      ],
+      starterExamples: [
+        ["# Example 1", "# root = build_tree([3, 5, 1, 6, 2, 0, 8, None, None, 7, 4])", "# p = find_node(root, 5)", "# q = find_node(root, 1)", "# lowest_common_ancestor(root, p, q).val"],
+        ["# Example 2", "# root = build_tree([3, 5, 1, 6, 2, 0, 8, None, None, 7, 4])", "# p = find_node(root, 5)", "# q = find_node(root, 4)", "# lowest_common_ancestor(root, p, q).val"],
+        ["# Example 3", "# root = build_tree([1, 2])", "# p = find_node(root, 1)", "# q = find_node(root, 2)", "# lowest_common_ancestor(root, p, q).val"]
+      ]
+    }
+  };
+
+  questions = questions.map(function(question) {
+    return Object.assign({}, question, questionMeta[question.id] || {});
+  });
+
+  var pyodideReady = null;
+
+  function resizeEditor(editor) {
+    editor.style.height = "auto";
+    editor.style.height = Math.max(editor.scrollHeight, 240) + "px";
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function buildCodeBlock(code, bigOComment) {
+    var decoratedCode = code;
+    if (bigOComment) {
+      decoratedCode = "# Big O: " + bigOComment + "\n" + code;
+    }
+    return "<pre><code>" + escapeHtml(decoratedCode) + "</code></pre>";
+  }
+
+  function buildCodeBlockWithExamples(code, bigOComment) {
+    var prefixParts = [];
+    if (bigOComment) {
+      prefixParts.unshift("# Big O: " + bigOComment);
+    }
+    var decoratedCode = prefixParts.length ? prefixParts.join("\n\n") + "\n\n" + code : code;
+    return "<pre><code>" + escapeHtml(decoratedCode) + "</code></pre>";
+  }
+
+  function buildStarterCode(question) {
+    var prefixParts = [];
+    var suffixCall = "";
+    if (question.examples && question.examples.length) {
+      (question.starterExamples || []).forEach(function(exampleBlock) {
+        if (!exampleBlock || !exampleBlock.length) {
+          return;
+        }
+        if (exampleBlock.length <= 2) {
+          prefixParts.push(exampleBlock[0]);
+          if (!suffixCall && exampleBlock[1]) {
+            suffixCall = exampleBlock[1];
+          }
+          return;
+        }
+        var label = exampleBlock[0];
+        var callLine = exampleBlock[exampleBlock.length - 1];
+        var setupLines = exampleBlock.slice(1, -1).map(function(line) {
+          return line.replace(/^#\s*/, "");
+        });
+        prefixParts.push(label);
+        prefixParts.push("# " + setupLines.join("; "));
+        if (!suffixCall) {
+          suffixCall = callLine;
+        }
+      });
+    }
+    var parts = [];
+    if (prefixParts.length) {
+      parts.push(prefixParts.join("\n"));
+    }
+    parts.push(question.starter);
+    if (suffixCall) {
+      parts.push(suffixCall);
+    }
+    return parts.join("\n\n");
+  }
+
+  function buildExamples(question) {
+    if (!question.examples || !question.examples.length) {
+      return "";
+    }
+    return [
+      '<div class="interactive-examples">',
+      question.examples.map(function(example, index) {
+        return '<div class="interactive-example"><strong>E' + (index + 1) + ".</strong> <code>" +
+          escapeHtml(example.input) + "</code> -> <code>" + escapeHtml(example.output) + "</code></div>";
+      }).join(""),
+      "</div>"
+    ].join("");
+  }
+
+  function buildSolutionDetails(question) {
+    return [
+      '<details class="solution">',
+      "  <summary>Show brute force and optimized solutions</summary>",
+      '  <div class="interactive-solution-section">',
+      "    <strong>Brute Force</strong>",
+           buildCodeBlockWithExamples(question.bruteForce || question.solution, question.bruteForceBigO),
+      "  </div>",
+      '  <div class="interactive-solution-section">',
+      "    <strong>Optimized</strong>",
+           buildCodeBlockWithExamples(question.solution, question.optimizedBigO),
+      "  </div>",
+      "</details>"
+    ].join("");
+  }
+
+  function createQuestionCard(question, index) {
+    var card = document.createElement("article");
+    card.className = "interactive-question-card";
+    card.setAttribute("data-question-id", question.id);
+    card.id = question.id;
+
+    var metaHtml = question.popularity
+      ? '<p class="interactive-question-meta">' + escapeHtml(question.popularity) + "</p>"
+      : "";
+
+    card.innerHTML = [
+      "<h4>" + (index + 1) + ". " + escapeHtml(question.title) + "</h4>",
+      metaHtml,
+      "<p>" + escapeHtml(question.prompt) + "</p>",
+      buildExamples(question),
+      '<div class="interactive-python-block">',
+      '  <div class="interactive-python-toolbar">',
+      '    <div class="interactive-python-actions">',
+      '      <button type="button" class="interactive-python-button run-button">Run</button>',
+      '      <button type="button" class="interactive-python-button check-button">Check answer</button>',
+      '      <button type="button" class="interactive-python-button reset-button">Reset</button>',
+      "    </div>",
+      "  </div>",
+      '  <textarea class="interactive-python-editor" spellcheck="false" aria-label="Interactive Python editor for ' + escapeHtml(question.title) + '"></textarea>',
+      '  <div class="interactive-python-status">Loading in-browser Python runtime…</div>',
+      '  <div class="interactive-python-output is-empty"></div>',
+      "</div>",
+      buildSolutionDetails(question)
+    ].join("");
+
+    var block = card.querySelector(".interactive-python-block");
+    block.style.width = "84ch";
+    block.style.maxWidth = "84ch";
+    var editor = card.querySelector(".interactive-python-editor");
+    editor.style.width = "80ch";
+    editor.style.maxWidth = "80ch";
+    editor.style.background = "#f1f3f5";
+
+    return card;
+  }
+
+  function resetCard(card, question) {
+    var editor = card.querySelector(".interactive-python-editor");
+    editor.value = buildStarterCode(question);
+    resizeEditor(editor);
+    card.querySelector(".interactive-python-output").innerHTML = "";
+    card.querySelector(".interactive-python-output").classList.add("is-empty");
+    card.querySelector(".interactive-python-status").textContent = "Ready. Use Run to iterate and Check answer to run examples plus edge cases.";
+  }
+
+  function renderOutput(outputNode, result, isCheckMode) {
+    var parts = [];
+
+    if (result.stdout) {
+      parts.push("<pre>" + escapeHtml(result.stdout) + "</pre>");
+    }
+
+    if (result.results && result.results.length) {
+      parts.push(
+        '<div class="interactive-check-results">' +
+          result.results.map(function(item) {
+            var statusClass = item.passed ? "pass" : "fail";
+            return [
+              '<div class="interactive-check-result ' + statusClass + '">',
+              '  <div class="interactive-check-result-title">' + escapeHtml((item.passed ? "Pass: " : "Fail: ") + item.name) + "</div>",
+              item.detail ? '  <div class="interactive-check-result-detail">' + escapeHtml(item.detail) + "</div>" : "",
+              "</div>"
+            ].join("");
+          }).join("") +
+        "</div>"
+      );
+    }
+
+    if (!parts.length && !isCheckMode) {
+      outputNode.innerHTML = "";
+      outputNode.classList.add("is-empty");
+      return;
+    }
+
+    if (!parts.length && isCheckMode) {
+      parts.push('<div class="interactive-check-results"><div class="interactive-check-result pass"><div class="interactive-check-result-title">Pass: no failing checks reported</div></div></div>');
+    }
+
+    outputNode.innerHTML = parts.join("");
+    outputNode.classList.remove("is-empty");
+  }
+
+  async function getPyodideRuntime() {
+    if (!pyodideReady) {
+      pyodideReady = (async function() {
+        var pyodide = await loadPyodide();
+        var setupByQuestion = {};
+        var checksByQuestion = {};
+
+        questions.forEach(function(question) {
+          setupByQuestion[question.id] = question.setup || "";
+          checksByQuestion[question.id] = question.checks || "";
+        });
+
+        var bootstrap = [
+          "import io",
+          "import contextlib",
+          "import traceback",
+          "",
+          "QUESTION_SETUP = " + JSON.stringify(setupByQuestion),
+          "QUESTION_CHECKS = " + JSON.stringify(checksByQuestion),
+          "",
+          "def safe_repr(value):",
+          "    try:",
+          "        return repr(value)",
+          "    except Exception:",
+          "        return '<unrepresentable>'",
+          "",
+          "def record_case(results, name, passed, actual=None, expected=None):",
+          "    detail_parts = []",
+          "    if expected is not None:",
+          "        detail_parts.append(f'expected: {safe_repr(expected)}')",
+          "    if actual is not None:",
+          "        detail_parts.append(f'actual: {safe_repr(actual)}')",
+          "    results.append({'name': name, 'passed': bool(passed), 'detail': '\\n'.join(detail_parts)})",
+          "",
+          "def check_equal(results, name, actual, expected):",
+          "    record_case(results, name, actual == expected, actual=actual, expected=expected)",
+          "",
+          "def check_true(results, name, condition, actual=None, expected='condition to be true'):",
+          "    record_case(results, name, bool(condition), actual=actual, expected=expected)",
+          "",
+          "def normalize_pair(value):",
+          "    if not isinstance(value, (list, tuple)) or len(value) != 2:",
+          "        raise AssertionError('Expected a list or tuple with exactly two indices.')",
+          "    return list(value)",
+          "",
+          "def normalize_nested(values):",
+          "    normalized = []",
+          "    for item in values:",
+          "        if isinstance(item, (list, tuple)):",
+          "            normalized.append(tuple(item))",
+          "        else:",
+          "            normalized.append((item,))",
+          "    return sorted(normalized)",
+          "",
+          "def run_merge_case(results, name, candidate, nums1, m, nums2, n, expected):",
+          "    working1 = list(nums1)",
+          "    working2 = list(nums2)",
+          "    returned = candidate(working1, m, working2, n)",
+          "    actual = returned if returned is not None else working1",
+          "    check_equal(results, name, actual, expected)",
+          "",
+          "def is_peak(nums, index):",
+          "    if not isinstance(index, int) or index < 0 or index >= len(nums):",
+          "        return False",
+          "    left = nums[index - 1] if index > 0 else float('-inf')",
+          "    right = nums[index + 1] if index < len(nums) - 1 else float('-inf')",
+          "    return nums[index] > left and nums[index] > right",
+          "",
+          "def __execute_user_code(user_code, namespace):",
+          "    stripped = user_code.rstrip()",
+          "    lines = stripped.splitlines() if stripped else []",
+          "    if not lines:",
+          "        return None",
+          "    try:",
+          "        compiled_last = compile(lines[-1], '<cell>', 'eval')",
+          "    except SyntaxError:",
+          "        exec(user_code, namespace)",
+          "        return None",
+          "    if len(lines) > 1:",
+          "        exec('\\n'.join(lines[:-1]), namespace)",
+          "    return eval(compiled_last, namespace)",
+          "",
+          "def __dsa_practice_run(question_id, user_code, check_mode=False):",
+          "    namespace = {}",
+          "    namespace['__builtins__'] = __builtins__",
+          "    namespace['normalize_pair'] = normalize_pair",
+          "    namespace['normalize_nested'] = normalize_nested",
+          "    namespace['is_peak'] = is_peak",
+          "    results = []",
+          "    namespace['check_equal'] = lambda name, actual, expected: check_equal(results, name, actual, expected)",
+          "    namespace['check_true'] = lambda name, condition, actual=None, expected='condition to be true': check_true(results, name, condition, actual, expected)",
+          "    namespace['run_merge_case'] = lambda name, candidate, nums1, m, nums2, n, expected: run_merge_case(results, name, candidate, nums1, m, nums2, n, expected)",
+          "    setup_code = QUESTION_SETUP.get(question_id, '')",
+          "    if setup_code:",
+          "        exec(setup_code, namespace)",
+          "    output = io.StringIO()",
+          "    error_output = None",
+          "    result_value = None",
+          "    try:",
+          "        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):",
+          "            result_value = __execute_user_code(user_code, namespace)",
+          "            if result_value is not None:",
+          "                print(safe_repr(result_value))",
+          "            if check_mode:",
+          "                exec(QUESTION_CHECKS.get(question_id, ''), namespace)",
+          "    except Exception:",
+          "        error_output = traceback.format_exc()",
+          "    return {'stdout': output.getvalue(), 'error': error_output, 'results': results}",
+          ""
+        ].join("\n");
+
+        await pyodide.runPythonAsync(bootstrap);
+        return pyodide;
+      })();
+    }
+    return pyodideReady;
+  }
+
+  async function runQuestion(card, question, checkMode) {
+    var status = card.querySelector(".interactive-python-status");
+    var output = card.querySelector(".interactive-python-output");
+    var editor = card.querySelector(".interactive-python-editor");
+    var buttons = card.querySelectorAll(".interactive-python-button");
+
+    buttons.forEach(function(button) {
+      button.disabled = true;
+    });
+    status.textContent = checkMode ? "Running checks…" : "Running…";
+
+    try {
+      var pyodide = await getPyodideRuntime();
+      var result = await pyodide.globals.get("__dsa_practice_run")(question.id, editor.value, checkMode).toJs({
+        dict_converter: Object.fromEntries
+      });
+
+      if (result.error) {
+        output.innerHTML = "<pre>" + escapeHtml(result.error) + "</pre>";
+        output.classList.remove("is-empty");
+        status.textContent = checkMode ? "Checks failed." : "Execution failed.";
+      } else {
+        renderOutput(output, result, checkMode);
+        if (checkMode) {
+          var allPassed = (result.results || []).every(function(item) {
+            return item.passed;
+          });
+          status.textContent = allPassed ? "All checks passed." : "Some checks failed.";
+        } else {
+          status.textContent = result.stdout ? "Execution complete." : "Execution complete. No output. Use Check answer to run cases.";
+        }
+      }
+    } catch (error) {
+      output.innerHTML = "<pre>" + escapeHtml(String(error)) + "</pre>";
+      output.classList.remove("is-empty");
+      status.textContent = "Runtime failed to load.";
+    } finally {
+      buttons.forEach(function(button) {
+        button.disabled = false;
+      });
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function() {
+    var container = document.getElementById("dsa-interactive-practice-list");
+    var otherContainer = document.getElementById("dsa-other-questions-list");
+    var otherSection = document.getElementById("dsa-other-questions");
+    var toggleButton = document.getElementById("toggle-all-dsa-solutions");
+
+    if (!container) {
+      return;
+    }
+
+    var mainQuestions = questions.filter(function(question) {
+      return question.group !== "other";
+    });
+    var otherQuestions = questions.filter(function(question) {
+      return question.group === "other";
+    });
+
+    mainQuestions.forEach(function(question, index) {
+      var card = createQuestionCard(question, index);
+      container.appendChild(card);
+      resetCard(card, question);
+
+      card.querySelector(".interactive-python-editor").addEventListener("input", function(event) {
+        resizeEditor(event.target);
+      });
+
+      card.querySelector(".run-button").addEventListener("click", function() {
+        runQuestion(card, question, false);
+      });
+
+      card.querySelector(".check-button").addEventListener("click", function() {
+        runQuestion(card, question, true);
+      });
+
+      card.querySelector(".reset-button").addEventListener("click", function() {
+        resetCard(card, question);
+      });
+    });
+
+    otherQuestions.forEach(function(question, index) {
+      var card = createQuestionCard(question, index);
+      if (otherContainer) {
+        otherContainer.appendChild(card);
+      }
+      resetCard(card, question);
+
+      card.querySelector(".interactive-python-editor").addEventListener("input", function(event) {
+        resizeEditor(event.target);
+      });
+
+      card.querySelector(".run-button").addEventListener("click", function() {
+        runQuestion(card, question, false);
+      });
+
+      card.querySelector(".check-button").addEventListener("click", function() {
+        runQuestion(card, question, true);
+      });
+
+      card.querySelector(".reset-button").addEventListener("click", function() {
+        resetCard(card, question);
+      });
+    });
+
+    if (otherSection && (!otherContainer || !otherContainer.children.length)) {
+      otherSection.style.display = "none";
+    }
+
+    var solutions = document.querySelectorAll("#dsa-interactive-practice-list details.solution, #dsa-other-questions-list details.solution");
+
+    function updateToggleButton() {
+      if (!toggleButton) {
+        return;
+      }
+      var allOpen = Array.from(solutions).every(function(solution) {
+        return solution.open;
+      });
+      toggleButton.textContent = allOpen ? "Hide all solutions" : "Show all solutions";
+      toggleButton.setAttribute("aria-expanded", allOpen ? "true" : "false");
+    }
+
+    if (toggleButton) {
+      toggleButton.addEventListener("click", function() {
+        var shouldOpen = !Array.from(solutions).every(function(solution) {
+          return solution.open;
+        });
+        solutions.forEach(function(solution) {
+          solution.open = shouldOpen;
+        });
+        updateToggleButton();
+      });
+    }
+
+    solutions.forEach(function(solution) {
+      solution.addEventListener("toggle", updateToggleButton);
+    });
+
+    getPyodideRuntime()
+      .then(function() {
+        document.querySelectorAll("#dsa-interactive-practice-list .interactive-python-status").forEach(function(node) {
+          node.textContent = "Ready. Use Run to iterate and Check answer to run examples plus edge cases.";
+        });
+      })
+      .catch(function() {
+        document.querySelectorAll("#dsa-interactive-practice-list .interactive-python-status").forEach(function(node) {
+          node.textContent = "Unable to load the in-browser runtime. Check network access and reload.";
+        });
+      });
+
+    updateToggleButton();
+  });
+})();
+</script>
 <script>
 gitbook.require(["gitbook"], function(gitbook) {
 gitbook.start({

--- a/data_science_prep/docs/pandas-practice.html
+++ b/data_science_prep/docs/pandas-practice.html
@@ -134,8 +134,9 @@ details.solution pre.sourceCode {
 }
 
 .solution-toggle-button {
-  float: right;
-  margin: 0.2em -150px 1em 1.5em;
+  float: none;
+  display: inline-block;
+  margin: 0.75em 0 1em 0;
   border: 1px solid #b8b8b8;
   background: #f5f5f5;
   color: #333;
@@ -152,8 +153,6 @@ details.solution pre.sourceCode {
 
 @media screen and (max-width: 1240px) {
   .solution-toggle-button {
-    float: none;
-    display: inline-block;
     margin: 0.75em 0 1em 0;
   }
 }
@@ -289,13 +288,14 @@ details.solution pre.sourceCode {
             <section class="normal" id="section-">
 <div id="pandas-practice" class="section level1 hasAnchor" number="7">
 <h1><span class="header-section-number">Chapter 7</span> Pandas Practice<a href="pandas-practice.html#pandas-practice" class="anchor-section" aria-label="Anchor link to header"></a></h1>
-<button type="button" class="solution-toggle-button" id="toggle-all-solutions" aria-expanded="false">Show all solutions</button>
 <p>This chapter is a focused drill on the pandas syntax that comes up most often in data science interviews. The questions use two small, consistent tables so you can stay in the flow of practicing rather than context-switching between datasets.</p>
 <p>The best workflow: read each prompt, write the answer from memory, then expand the solution to check. For the trickier questions, say out loud why you reached for <code>groupby</code>, <code>agg</code>, <code>merge</code>, or <code>transform</code>.</p>
+<p>For the interactive boxes below, use <code>Run</code> to test your answer and <code>Reset</code> to restore the starter code. Each run starts from a fresh copy of the same preloaded data.</p>
+<button type="button" class="solution-toggle-button" id="toggle-all-solutions" aria-expanded="false">Show all solutions</button>
 
 <div id="data-setup" class="section level2 hasAnchor" number="7.1">
 <h2><span class="header-section-number">7.1</span> Data Setup<a href="pandas-practice.html#data-setup" class="anchor-section" aria-label="Anchor link to header"></a></h2>
-<p>Run the cell below to create the two DataFrames used throughout this chapter. You can work interactively in any Python 3.10+ environment — <a href="https://colab.research.google.com/">Google Colab</a> is a convenient zero-install option.</p>
+<p>If you want to work through these exercises outside the interactive page, run the cell below to create the two DataFrames used throughout this chapter. Any Python 3.10+ environment will work, and <a href="https://colab.research.google.com/">Google Colab</a> is a convenient zero-install option.</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="pandas-practice.html#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> pandas <span class="im">as</span> pd</span>
 <span id="cb1-2"><a href="pandas-practice.html#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> numpy <span class="im">as</span> np</span>
 <span id="cb1-3"><a href="pandas-practice.html#cb1-3" aria-hidden="true" tabindex="-1"></a></span>
@@ -462,23 +462,33 @@ orders["category_label"] = [label_map[x] for x in orders["category"]]</code></pr
 <p><em><code>.map(dict)</code> is the idiomatic way to recode a categorical column. For more complex multi-condition logic, reach for <code>np.select</code> or <code>pd.cut</code>.</em></p>
 </details>
 
+<p><strong>Q13.</strong> Create an <code>amount_bucket</code> column that groups <code>amount</code> into <code>"low"</code>, <code>"medium"</code>, and <code>"high"</code> using cut points 0, 50, and 90.</p>
+<details class="solution"><summary>Solution</summary>
+<div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders["amount_bucket"] = pd.cut(
+    orders["amount"],
+    bins=[0, 50, 90, float("inf")],
+    labels=["low", "medium", "high"]
+)</code></pre></div>
+<p><em><code>pd.cut</code> is useful when you want interview-friendly bucket logic without manually chaining conditions. Values outside the bins or missing values remain <code>NaN</code>.</em></p>
+</details>
+
 </div>
 
 <!-- ============================================================ -->
 <div id="groupby" class="section level2 hasAnchor" number="7.6">
 <h2><span class="header-section-number">7.6</span> Groupby<a href="pandas-practice.html#groupby" class="anchor-section" aria-label="Anchor link to header"></a></h2>
 
-<p><strong>Q13.</strong> Find total <code>amount</code> by <code>customer_id</code>.</p>
+<p><strong>Q14.</strong> Find total <code>amount</code> by <code>customer_id</code>.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.groupby("customer_id")["amount"].sum()</code></pre></div>
 </details>
 
-<p><strong>Q14.</strong> Find average <code>amount</code> by <code>category</code>.</p>
+<p><strong>Q15.</strong> Find average <code>amount</code> by <code>category</code>.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.groupby("category")["amount"].mean()</code></pre></div>
 </details>
 
-<p><strong>Q15.</strong> Find both the count of orders and total amount by <code>customer_id</code> in one call.</p>
+<p><strong>Q16.</strong> Find both the count of orders and total amount by <code>customer_id</code> in one call.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.groupby("customer_id").agg(
     order_count=("order_id", "count"),
@@ -487,12 +497,12 @@ orders["category_label"] = [label_map[x] for x in orders["category"]]</code></pr
 <p><em>Named aggregation syntax <code>(col, func)</code> is the modern replacement for the older <code>{"col": func}</code> dict syntax. Prefer it — it avoids MultiIndex columns.</em></p>
 </details>
 
-<p><strong>Q16.</strong> Find the max order amount for each <code>category</code>.</p>
+<p><strong>Q17.</strong> Find the max order amount for each <code>category</code>.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.groupby("category")["amount"].max()</code></pre></div>
 </details>
 
-<p><strong>Q17.</strong> Find which <code>customer_id</code> has spent the most in total.</p>
+<p><strong>Q18.</strong> Find which <code>customer_id</code> has spent the most in total.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.groupby("customer_id")["amount"].sum().idxmax()</code></pre></div>
 <p><em><code>idxmax()</code> returns the index label of the maximum value — here, the customer_id. <code>max()</code> would return the value itself.</em></p>
@@ -504,19 +514,19 @@ orders["category_label"] = [label_map[x] for x in orders["category"]]</code></pr
 <div id="merge-and-join" class="section level2 hasAnchor" number="7.7">
 <h2><span class="header-section-number">7.7</span> Merge and Join<a href="pandas-practice.html#merge-and-join" class="anchor-section" aria-label="Anchor link to header"></a></h2>
 
-<p><strong>Q18.</strong> Join <code>orders</code> with <code>customers</code> to bring in <code>name</code> and <code>city</code>.</p>
+<p><strong>Q19.</strong> Join <code>orders</code> with <code>customers</code> to bring in <code>name</code> and <code>city</code>.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.merge(customers[["customer_id", "name", "city"]], on="customer_id", how="inner")</code></pre></div>
 <p><em>Selecting only the needed columns from the right table before merging avoids ending up with unwanted columns.</em></p>
 </details>
 
-<p><strong>Q19.</strong> After joining orders to customers, find total sales by <code>city</code>.</p>
+<p><strong>Q20.</strong> After joining orders to customers, find total sales by <code>city</code>.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">merged = orders.merge(customers[["customer_id", "city"]], on="customer_id")
 merged.groupby("city")["amount"].sum()</code></pre></div>
 </details>
 
-<p><strong>Q20.</strong> Do a left join from <code>customers</code> to <code>orders</code> and identify customers who have no orders.</p>
+<p><strong>Q21.</strong> Do a left join from <code>customers</code> to <code>orders</code> and identify customers who have no orders.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">left = customers.merge(orders, on="customer_id", how="left")
 left[left["order_id"].isna()][["customer_id", "name"]]</code></pre></div>
@@ -529,17 +539,17 @@ left[left["order_id"].isna()][["customer_id", "name"]]</code></pre></div>
 <div id="missing-data" class="section level2 hasAnchor" number="7.8">
 <h2><span class="header-section-number">7.8</span> Missing Data<a href="pandas-practice.html#missing-data" class="anchor-section" aria-label="Anchor link to header"></a></h2>
 
-<p><strong>Q21.</strong> Count missing values in each column of <code>orders</code>.</p>
+<p><strong>Q22.</strong> Count missing values in each column of <code>orders</code>.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.isna().sum()</code></pre></div>
 </details>
 
-<p><strong>Q22.</strong> Fill missing <code>amount</code> values with the median amount.</p>
+<p><strong>Q23.</strong> Fill missing <code>amount</code> values with the median amount.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders["amount"].fillna(orders["amount"].median())</code></pre></div>
 </details>
 
-<p><strong>Q23.</strong> Drop rows where <code>amount</code> is missing.</p>
+<p><strong>Q24.</strong> Drop rows where <code>amount</code> is missing.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.dropna(subset=["amount"])</code></pre></div>
 <p><em>Always prefer <code>subset=</code> over bare <code>dropna()</code> to avoid accidentally dropping rows just because an unrelated column is null.</em></p>
@@ -551,18 +561,18 @@ left[left["order_id"].isna()][["customer_id", "name"]]</code></pre></div>
 <div id="dates" class="section level2 hasAnchor" number="7.9">
 <h2><span class="header-section-number">7.9</span> Dates<a href="pandas-practice.html#dates" class="anchor-section" aria-label="Anchor link to header"></a></h2>
 
-<p><strong>Q24.</strong> Extract the day-of-month from <code>order_date</code> into a new column <code>day</code>.</p>
+<p><strong>Q25.</strong> Extract the day-of-month from <code>order_date</code> into a new column <code>day</code>.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.assign(day=orders["order_date"].dt.day)</code></pre></div>
 <p><em>The <code>.dt</code> accessor exposes all datetime components: <code>.dt.year</code>, <code>.dt.month</code>, <code>.dt.day</code>, <code>.dt.dayofweek</code>, <code>.dt.hour</code>, etc.</em></p>
 </details>
 
-<p><strong>Q25.</strong> Filter orders placed in January 2025.</p>
+<p><strong>Q26.</strong> Filter orders placed in January 2025.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders[orders["order_date"].dt.month == 1]</code></pre></div>
 </details>
 
-<p><strong>Q26.</strong> After merging orders with customers, find the number of days between each customer's <code>signup_date</code> and their order date.</p>
+<p><strong>Q27.</strong> After merging orders with customers, find the number of days between each customer's <code>signup_date</code> and their order date.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">merged = orders.merge(customers[["customer_id", "signup_date"]], on="customer_id")
 merged.assign(days_since_signup=(merged["order_date"] - merged["signup_date"]).dt.days)</code></pre></div>
@@ -575,7 +585,7 @@ merged.assign(days_since_signup=(merged["order_date"] - merged["signup_date"]).d
 <div id="reshaping" class="section level2 hasAnchor" number="7.10">
 <h2><span class="header-section-number">7.10</span> Reshaping<a href="pandas-practice.html#reshaping" class="anchor-section" aria-label="Anchor link to header"></a></h2>
 
-<p><strong>Q27.</strong> Create a pivot table showing total <code>amount</code> by <code>customer_id</code> (rows) and <code>category</code> (columns).</p>
+<p><strong>Q28.</strong> Create a pivot table showing total <code>amount</code> by <code>customer_id</code> (rows) and <code>category</code> (columns).</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.pivot_table(
     index="customer_id",
@@ -585,7 +595,7 @@ merged.assign(days_since_signup=(merged["order_date"] - merged["signup_date"]).d
 )</code></pre></div>
 </details>
 
-<p><strong>Q28.</strong> Create a pivot table showing mean <code>amount</code> by <code>city</code> (rows) and <code>category</code> (columns).</p>
+<p><strong>Q29.</strong> Create a pivot table showing mean <code>amount</code> by <code>city</code> (rows) and <code>category</code> (columns).</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">merged = orders.merge(customers[["customer_id", "city"]], on="customer_id")
 merged.pivot_table(
@@ -602,7 +612,7 @@ merged.pivot_table(
 <div id="ranking-and-window-style" class="section level2 hasAnchor" number="7.11">
 <h2><span class="header-section-number">7.11</span> Ranking and Window-Style<a href="pandas-practice.html#ranking-and-window-style" class="anchor-section" aria-label="Anchor link to header"></a></h2>
 
-<p><strong>Q29.</strong> Within each <code>customer_id</code>, rank orders by <code>amount</code> descending (rank 1 = largest).</p>
+<p><strong>Q30.</strong> Within each <code>customer_id</code>, rank orders by <code>amount</code> descending (rank 1 = largest).</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.assign(
     rank=orders.groupby("customer_id")["amount"].rank(method="dense", ascending=False)
@@ -610,7 +620,7 @@ merged.pivot_table(
 <p><em><code>method="dense"</code> gives tied values the same rank without gaps. <code>method="min"</code> skips ranks; <code>method="first"</code> assigns unique ranks in order of appearance.</em></p>
 </details>
 
-<p><strong>Q30.</strong> For each customer, compute a running total of <code>amount</code> ordered by <code>order_date</code>.</p>
+<p><strong>Q31.</strong> For each customer, compute a running total of <code>amount</code> ordered by <code>order_date</code>.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders_sorted = orders.sort_values("order_date")
 orders_sorted.assign(
@@ -619,7 +629,7 @@ orders_sorted.assign(
 <p><em>Sort before <code>cumsum()</code> — groupby preserves existing row order within each group, so the sort must happen first.</em></p>
 </details>
 
-<p><strong>Q31.</strong> For each customer, get the previous order's amount using <code>shift</code>.</p>
+<p><strong>Q32.</strong> For each customer, get the previous order's amount using <code>shift</code>.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders_sorted = orders.sort_values(["customer_id", "order_date"])
 orders_sorted.assign(
@@ -635,24 +645,24 @@ orders_sorted.assign(
 <h2><span class="header-section-number">7.12</span> Interview Prompts<a href="pandas-practice.html#interview-prompts" class="anchor-section" aria-label="Anchor link to header"></a></h2>
 <p>These questions are phrased the way an interviewer would ask them. They require you to chain multiple operations together.</p>
 
-<p><strong>Q32.</strong> Find each customer's first order date.</p>
+<p><strong>Q33.</strong> Find each customer's first order date.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.groupby("customer_id")["order_date"].min()</code></pre></div>
 </details>
 
-<p><strong>Q33.</strong> Find customers who made more than one order.</p>
+<p><strong>Q34.</strong> Find customers who made more than one order.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">counts = orders.groupby("customer_id")["order_id"].count()
 counts[counts &gt; 1].index.tolist()</code></pre></div>
 </details>
 
-<p><strong>Q34.</strong> Find categories where the average order amount is greater than 50.</p>
+<p><strong>Q35.</strong> Find categories where the average order amount is greater than 50.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">avg = orders.groupby("category")["amount"].mean()
 avg[avg &gt; 50].index.tolist()</code></pre></div>
 </details>
 
-<p><strong>Q35.</strong> For each city, find the customer with the highest total spend.</p>
+<p><strong>Q36.</strong> For each city, find the customer with the highest total spend.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">spend = (
     orders.groupby("customer_id")["amount"]
@@ -664,19 +674,19 @@ spend.loc[spend.groupby("city")["total_spend"].idxmax()]</code></pre></div>
 <p><em><code>idxmax()</code> returns the index labels of the per-group maxima. Passing those to <code>.loc[]</code> retrieves the full rows.</em></p>
 </details>
 
-<p><strong>Q36.</strong> Find the percentage of total sales contributed by each category.</p>
+<p><strong>Q37.</strong> Find the percentage of total sales contributed by each category.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">cat_totals = orders.groupby("category")["amount"].sum()
 (cat_totals / cat_totals.sum() * 100).round(2)</code></pre></div>
 </details>
 
-<p><strong>Q37.</strong> Return the top 2 largest orders per customer.</p>
+<p><strong>Q38.</strong> Return the top 2 largest orders per customer.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.sort_values("amount", ascending=False).groupby("customer_id").head(2)</code></pre></div>
 <p><em>Sort globally first, then <code>groupby().head(n)</code> takes the first n rows per group — which are the largest after sorting descending.</em></p>
 </details>
 
-<p><strong>Q38.</strong> Find customers whose order amounts are strictly increasing over time.</p>
+<p><strong>Q39.</strong> Find customers whose order amounts are strictly increasing over time.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">def is_strictly_increasing(s):
     vals = s.dropna().tolist()
@@ -691,14 +701,14 @@ result[result].index.tolist()</code></pre></div>
 <p><em>Customers with only one order trivially satisfy this (the <code>all()</code> over an empty iterator returns <code>True</code>). Filter with <code>groupby().filter(lambda g: len(g) &gt; 1)</code> first if that matters.</em></p>
 </details>
 
-<p><strong>Q39.</strong> Find the gap in days between each order and the previous order for the same customer.</p>
+<p><strong>Q40.</strong> Find the gap in days between each order and the previous order for the same customer.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">df = orders.sort_values(["customer_id", "order_date"]).copy()
 df["prev_date"] = df.groupby("customer_id")["order_date"].shift(1)
 df["days_gap"] = (df["order_date"] - df["prev_date"]).dt.days</code></pre></div>
 </details>
 
-<p><strong>Q40.</strong> Build a summary table with one row per customer: total orders, total spend, average order amount, and most recent order date.</p>
+<p><strong>Q41.</strong> Build a summary table with one row per customer: total orders, total spend, average order amount, and most recent order date.</p>
 <details class="solution"><summary>Solution</summary>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python">orders.groupby("customer_id").agg(
     total_orders=("order_id", "count"),
@@ -757,28 +767,37 @@ df["days_gap"] = (df["order_date"] - df["prev_date"]).dt.days</code></pre></div>
   ].join("\n");
 
   var defaultCellCode = [
-    "# pandas is available as pd",
-    "# orders and customers are preloaded",
+    "# orders and customers are loaded",
     "orders.head()"
   ].join("\n");
 
   var pyodideReady = null;
 
+  function resizeEditor(editor) {
+    editor.style.height = "auto";
+    editor.style.height = editor.scrollHeight + "px";
+  }
+
   function createCell(index) {
     var wrapper = document.createElement("div");
     wrapper.className = "interactive-python-block";
+    wrapper.style.width = "84ch";
+    wrapper.style.maxWidth = "84ch";
     wrapper.innerHTML = [
       '<div class="interactive-python-toolbar">',
-      '  <div class="interactive-python-label">Interactive Python practice</div>',
       '  <div class="interactive-python-actions">',
       '    <button type="button" class="interactive-python-button run-button">Run</button>',
       '    <button type="button" class="interactive-python-button reset-button">Reset</button>',
       '  </div>',
       "</div>",
       '<textarea class="interactive-python-editor" spellcheck="false" aria-label="Interactive Python editor for question ' + index + '"></textarea>',
-      '<div class="interactive-python-status">Loading in-browser Python and pandas runtime…</div>',
+      '<div class="interactive-python-status"></div>',
       '<div class="interactive-python-output is-empty"></div>'
     ].join("");
+    var editor = wrapper.querySelector(".interactive-python-editor");
+    editor.style.width = "80ch";
+    editor.style.maxWidth = "80ch";
+    editor.style.background = "#f1f3f5";
     return wrapper;
   }
 
@@ -882,10 +901,12 @@ df["days_gap"] = (df["order_date"] - df["prev_date"]).dt.days</code></pre></div>
   }
 
   function resetCell(cell) {
-    cell.querySelector(".interactive-python-editor").value = defaultCellCode;
+    var editor = cell.querySelector(".interactive-python-editor");
+    editor.value = defaultCellCode;
+    resizeEditor(editor);
     cell.querySelector(".interactive-python-output").innerHTML = "";
     cell.querySelector(".interactive-python-output").classList.add("is-empty");
-    cell.querySelector(".interactive-python-status").textContent = "Ready. orders, customers, pd, and np are loaded fresh on each run.";
+    cell.querySelector(".interactive-python-status").textContent = "";
   }
 
   document.addEventListener("DOMContentLoaded", function() {
@@ -932,6 +953,10 @@ df["days_gap"] = (df["order_date"] - df["prev_date"]).dt.days</code></pre></div>
 
       solution.addEventListener("toggle", updateToggleButton);
 
+      cell.querySelector(".interactive-python-editor").addEventListener("input", function(event) {
+        resizeEditor(event.target);
+      });
+
       cell.querySelector(".run-button").addEventListener("click", function() {
         runCell(cell);
       });
@@ -944,7 +969,7 @@ df["days_gap"] = (df["order_date"] - df["prev_date"]).dt.days</code></pre></div>
     getPyodideRuntime()
       .then(function() {
         document.querySelectorAll(".interactive-python-status").forEach(function(node) {
-          node.textContent = "Ready. orders, customers, pd, and np are loaded fresh on each run.";
+          node.textContent = "";
         });
       })
       .catch(function() {

--- a/data_science_prep/docs/style.css
+++ b/data_science_prep/docs/style.css
@@ -42,7 +42,13 @@ h4,h5,h6{
   padding: 0.9rem 1rem 1rem;
   border: 1px solid #d8dee9;
   border-radius: 8px;
-  background: #fbfcfe;
+  background: #f1f4f8;
+  position: relative;
+  left: 50%;
+  width: min(1500px, calc(100vw - 120px));
+  margin-left: calc(-1 * min(750px, calc((100vw - 120px) / 2)));
+  max-width: none;
+  box-sizing: border-box;
 }
 
 .interactive-python-toolbar {
@@ -87,15 +93,17 @@ h4,h5,h6{
 
 .interactive-python-editor {
   width: 100%;
-  min-height: 130px;
+  min-height: 240px;
   resize: vertical;
   border: 1px solid #ccd6e3;
   border-radius: 6px;
-  background: #ffffff;
+  background: #f7f9fc;
   padding: 0.8rem;
   font: 0.95rem/1.5 SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
   color: #1f2937;
   box-sizing: border-box;
+  overflow-y: hidden;
+  max-width: none;
 }
 
 .interactive-python-status {
@@ -137,4 +145,104 @@ h4,h5,h6{
 
 .interactive-python-output tr:nth-child(even) {
   background: #f8fbff;
+}
+
+.interactive-practice-intro {
+  margin: 0.75rem 0 1.1rem;
+  color: #334155;
+}
+
+.interactive-practice-controls {
+  margin: 0.8rem 0 1rem;
+}
+
+.interactive-question-card {
+  margin: 1.1rem 0 1.4rem;
+  padding: 1rem 1.05rem 1.1rem;
+  border: 1px solid #d8dee9;
+  border-radius: 10px;
+  background: #ffffff;
+}
+
+.interactive-question-card h4 {
+  margin: 0 0 0.45rem;
+  font-size: 1.05rem;
+}
+
+.interactive-question-meta {
+  margin: 0 0 0.75rem;
+  color: #55657d;
+  font-size: 0.9rem;
+}
+
+.interactive-question-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.75rem 0;
+}
+
+.interactive-question-tag {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: #eef4fb;
+  color: #28415e;
+  font-size: 0.82rem;
+}
+
+.interactive-question-card details.solution {
+  margin-top: 0.9rem;
+}
+
+.interactive-examples {
+  margin: 0.75rem 0 0.9rem;
+}
+
+.interactive-example {
+  margin-top: 0.35rem;
+  padding: 0.45rem 0.55rem;
+  border-left: 3px solid #d8dee9;
+  background: #fbfcfe;
+}
+
+.interactive-solution-section {
+  margin-top: 0.9rem;
+}
+
+.interactive-solution-section pre {
+  margin-top: 0.35rem;
+}
+
+.interactive-check-results {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.interactive-check-result {
+  border: 1px solid #dde5ef;
+  border-radius: 6px;
+  padding: 0.6rem 0.7rem;
+  background: #fbfcfe;
+}
+
+.interactive-check-result.pass {
+  border-color: #b7dfc1;
+  background: #f3fbf4;
+}
+
+.interactive-check-result.fail {
+  border-color: #e6b8b8;
+  background: #fff6f6;
+}
+
+.interactive-check-result-title {
+  font-weight: 600;
+  color: #233044;
+}
+
+.interactive-check-result-detail {
+  margin-top: 0.2rem;
+  color: #55657d;
+  white-space: pre-wrap;
 }

--- a/data_science_prep/style.css
+++ b/data_science_prep/style.css
@@ -36,3 +36,213 @@ h4,h5,h6{
   font-size: 12pt;
   font-weight: bold;
 }
+
+.interactive-python-block {
+  margin: 0.85rem 0 0.6rem;
+  padding: 0.9rem 1rem 1rem;
+  border: 1px solid #d8dee9;
+  border-radius: 8px;
+  background: #f1f4f8;
+  position: relative;
+  left: 50%;
+  width: min(1500px, calc(100vw - 120px));
+  margin-left: calc(-1 * min(750px, calc((100vw - 120px) / 2)));
+  max-width: none;
+  box-sizing: border-box;
+}
+
+.interactive-python-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.interactive-python-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #233044;
+}
+
+.interactive-python-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.interactive-python-button {
+  border: 1px solid #b7c4d6;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #233044;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.2;
+}
+
+.interactive-python-button:hover:not(:disabled) {
+  background: #eef4fb;
+}
+
+.interactive-python-button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.interactive-python-editor {
+  width: 100%;
+  min-height: 240px;
+  resize: vertical;
+  border: 1px solid #ccd6e3;
+  border-radius: 6px;
+  background: #f7f9fc;
+  padding: 0.8rem;
+  font: 0.95rem/1.5 SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  color: #1f2937;
+  box-sizing: border-box;
+  overflow-y: hidden;
+  max-width: none;
+}
+
+.interactive-python-status {
+  margin-top: 0.55rem;
+  font-size: 0.88rem;
+  color: #55657d;
+}
+
+.interactive-python-output {
+  margin-top: 0.75rem;
+  padding: 0.85rem;
+  border-radius: 6px;
+  background: #ffffff;
+  border: 1px solid #dde5ef;
+  overflow-x: auto;
+}
+
+.interactive-python-output.is-empty {
+  display: none;
+}
+
+.interactive-python-output pre {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.interactive-python-output table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.interactive-python-output th,
+.interactive-python-output td {
+  border: 1px solid #d9e1eb;
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+}
+
+.interactive-python-output tr:nth-child(even) {
+  background: #f8fbff;
+}
+
+.interactive-practice-intro {
+  margin: 0.75rem 0 1.1rem;
+  color: #334155;
+}
+
+.interactive-practice-controls {
+  margin: 0.8rem 0 1rem;
+}
+
+.interactive-question-card {
+  margin: 1.1rem 0 1.4rem;
+  padding: 1rem 1.05rem 1.1rem;
+  border: 1px solid #d8dee9;
+  border-radius: 10px;
+  background: #ffffff;
+}
+
+.interactive-question-card h4 {
+  margin: 0 0 0.45rem;
+  font-size: 1.05rem;
+}
+
+.interactive-question-meta {
+  margin: 0 0 0.75rem;
+  color: #55657d;
+  font-size: 0.9rem;
+}
+
+.interactive-question-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.75rem 0;
+}
+
+.interactive-question-tag {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: #eef4fb;
+  color: #28415e;
+  font-size: 0.82rem;
+}
+
+.interactive-question-card details.solution {
+  margin-top: 0.9rem;
+}
+
+.interactive-examples {
+  margin: 0.75rem 0 0.9rem;
+}
+
+.interactive-example {
+  margin-top: 0.35rem;
+  padding: 0.45rem 0.55rem;
+  border-left: 3px solid #d8dee9;
+  background: #fbfcfe;
+}
+
+.interactive-solution-section {
+  margin-top: 0.9rem;
+}
+
+.interactive-solution-section pre {
+  margin-top: 0.35rem;
+}
+
+.interactive-check-results {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.interactive-check-result {
+  border: 1px solid #dde5ef;
+  border-radius: 6px;
+  padding: 0.6rem 0.7rem;
+  background: #fbfcfe;
+}
+
+.interactive-check-result.pass {
+  border-color: #b7dfc1;
+  background: #f3fbf4;
+}
+
+.interactive-check-result.fail {
+  border-color: #e6b8b8;
+  background: #fff6f6;
+}
+
+.interactive-check-result-title {
+  font-weight: 600;
+  color: #233044;
+}
+
+.interactive-check-result-detail {
+  margin-top: 0.2rem;
+  color: #55657d;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
This PR upgrades the interactive practice experience for both pandas and DSA, and restructures the DSA chapter around browser-run interview drills instead of static worked examples. It also adds the missing pandas pd.cut prompt, improves editor behavior and sizing, and makes the DSA material easier to navigate through grouped sections and TOC links.

- `docs/computer-science-data-scructures-and-algorithms.html` - Replaces the old DSA content with interactive popular-question and other-question sections, adds answer checking, starter examples, brute-force and optimized solutions, sourced section framing, and generated TOC anchors.
- `docs/pandas-practice.html` - Adds the amount_bucket / pd.cut exercise, renumbers later prompts, simplifies the top-of-section instructions, and refines the interactive editor and solutions-toggle behavior.
- `docs/style.css`, `style.css` - Introduces shared styling for the interactive practice UI, including editor/ output cards, examples, solution areas, and answer-check result states.