### PR TITLE
fix(publications): repair the dead abstract expanders and tidy the footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,16 +574,16 @@ reference sets</a>. Poster presented at: 2023 OHDSI Symposium; October 20, 2023;
                         <ul class="left-side">
                             <li>© Robert Brown 2026</li>
                             <li>
-                                <a target="_blank" href="/CV.pdf">
-                                    Curriculum Vitae <i class="fa fa-file-pdf-o"></i>
-                                </a>
-                            </li>
-                            <li>
                                 <span class="email"></span>
                             </li>
                             <li>
                                 <a target="_blank" href="https://www.linkedin.com/in/rbtbrwn/">
                                     <i class="fa fa-linkedin"></i>
+                                </a>
+                            </li>
+                            <li>
+                                <a target="_blank" href="https://github.com/elreb">
+                                    <i class="fa fa-github"></i>
                                 </a>
                             </li>
                         </ul>

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
                             <h2>Education</h2>
                         </div>
                         <div class="col-md-10 col-lg-9">
-                            <h3 class="school">University of California - Berkeley</h3>
+                            <h3 class="school">University of California, Berkeley</h3>
                             <p class="location">Berkeley, CA</p>
                             <div class="clearfix"></div>
                             <div class="clearfix"></div>

--- a/js/base.min.js
+++ b/js/base.min.js
@@ -5869,24 +5869,7 @@ $(document).ready(function() {
         }
     }),
     $("#mainnav").scrollToFixed();
-    document.getElementById("js-expander-trigger"),
-    document.getElementById("js-expander-content");
-    $("#js-expander-trigger2").click(function() {
-        $(this).toggleClass("expander-hidden")
-    }),
-    $("#js-expander-trigger3").click(function() {
-        $(this).toggleClass("expander-hidden")
-    }),
-    $("#js-expander-trigger96").click(function() {
-        $(this).toggleClass("expander-hidden")
-    }),
-    $("#js-expander-trigger97").click(function() {
-        $(this).toggleClass("expander-hidden")
-    }),
-    $("#js-expander-trigger98").click(function() {
-        $(this).toggleClass("expander-hidden")
-    }),
-    $("#js-expander-trigger99").click(function() {
+    $(".expander-trigger").click(function() {
         $(this).toggleClass("expander-hidden")
     }),
     $(".accordion-tabs").each(function(t) {


### PR DESCRIPTION
Fixes the expand buttons for publication abstracts that had never worked.

## Changes by area

### Publications

- `js/base.min.js`: Binds the abstract expanders on the shared `expander-trigger` class instead of on six individual ids. The script bound handlers to the ids 2, 3, 96, 97, 98 and 99, but the markup numbers were different. 

### Footer

- `index.html`: Removes the curriculum vitae link, which duplicated the one already in the masthead, and adds a GitHub link alongside LinkedIn.

